### PR TITLE
feat: HA 2026 compatibility (v2.0.0)

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,12 @@
+name: Validate with hassfest
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: home-assistant/actions/hassfest@master

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,15 @@
+name: Lint
+on:
+  push:
+  pull_request:
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - run: pip install ruff
+      - run: ruff check .
+      - run: ruff format --check .

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -13,3 +13,4 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
+          ignore: "brands"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,15 @@
+name: HACS Validation
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v4"
+      - name: HACS validation
+        uses: "hacs/action@main"
+        with:
+          category: "integration"

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ venv.bak/
 .storage/
 home-assistant.log
 home-assistant_v2.db
+
+# Linters / type checkers
+.mypy_cache/
+.ruff_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [--write-changes]
+        exclude: "^(poetry.lock|requirements.*\\.txt)$"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to SKSoft Dimmer Engine are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-05-26
+
+### Breaking Changes
+
+- **Conditions now require the `options:` key** — condition parameters (`lights`) must be nested under `options:` to comply with the HA 2024.12+ conditions framework. The old flat syntax is no longer supported.
+
+  ```yaml
+  # Before (v1.x)
+  condition:
+    - condition: sksoft_dimmer_engine.is_cycle_dimming
+      lights:
+        - light.living_room
+
+  # After (v2.0.0+)
+  condition:
+    - condition: sksoft_dimmer_engine.is_cycle_dimming
+      options:
+        lights:
+          - light.living_room
+  ```
+
+- **Minimum Home Assistant version is now 2024.12** — the new class-based conditions framework (`homeassistant.helpers.condition.Condition`) is required.
+
+### Added
+
+- `condition.py` — new module implementing class-based `IsCycleDimmingCondition` and `IsCCWCyclingCondition` using the `Condition` base class from `homeassistant.helpers.condition`
+- `conditions.yaml` — declarative condition schema with entity selectors for `is_cycle_dimming` and `is_ccw_cycling`
+- `storage.py` — dedicated storage module for registry persistence, replacing inline storage logic in `__init__.py`
+- `async_get_conditions` entry point registered in `__init__.py` for HA to discover integration conditions
+
+### Changed
+
+- Conditions are now registered via the modern `async_get_conditions` / `Condition` class pattern instead of the legacy `condition` platform
+- All example automations and scripts updated to use `action:` instead of the deprecated `service:` key
+- README updated with HA minimum version requirement, modernized installation steps, updated condition syntax examples, and an expanded Troubleshooting section
+
+### Removed
+
+- Legacy flat condition syntax support (parameters directly under `condition:` without `options:`)
+
+## [1.2.0] - 2024-xx-xx
+
+- Added CCW (color temperature) cycling: `start_ccw`, `stop_ccw`, `stop_all_ccw` services and `is_ccw_cycling` condition
+
+## [1.1.4] - 2024-xx-xx
+
+- Fixed cycle dimming to only update lights that are currently on
+
+## [1.0.0] - 2024-xx-xx
+
+- Initial release with sine-wave brightness cycling, multi-light support, phase synchronization, and persistence

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 A custom Home Assistant integration that provides a sine-wave, time-based brightness cycling engine for one or more Light entities. It runs a single shared async loop for all active lights, making it efficient and lightweight.
 
+> **Minimum Home Assistant version: 2024.12**
+> This integration uses the modern conditions framework introduced in HA 2024.12. Earlier versions are not supported.
+
 ## Features
 
 - **Sine-wave brightness cycling**: Smoothly cycles light brightness using a sine wave pattern
@@ -12,23 +15,28 @@ A custom Home Assistant integration that provides a sine-wave, time-based bright
 - **Persistence**: Registry is saved and restored across Home Assistant restarts
 - **Efficient**: Single async loop for all lights, minimal resource usage
 - **Configurable**: Adjust period, brightness range, tick interval, and more
+- **Modern conditions**: Native integration with HA 2024.12+ conditions framework
 
 ## Installation
 
 ### HACS Installation (Recommended)
 
 1. Click the button at the top of this page to open HACS in your Home Assistant instance
-2. Click "Download" to install the integration
+2. Click **Download** to install the integration
 3. Restart Home Assistant
-4. Go to Settings → Devices & Services → Add Integration
-5. Search for "SKSoft Dimmer Engine" and click to add it
+4. Go to **Settings → Devices & Services → Add Integration**
+5. Search for **SKSoft Dimmer Engine** and click to add it
 
 ### Manual Installation
 
-1. Copy the `custom_components/sksoft_dimmer_engine` folder to your Home Assistant `custom_components` directory
-2. Restart Home Assistant
-3. Go to Settings → Devices & Services → Add Integration
-4. Search for "SKSoft Dimmer Engine" and click to add it
+1. Download or clone this repository
+2. Copy the `custom_components/sksoft_dimmer_engine` folder into your Home Assistant `custom_components` directory:
+   ```
+   <config>/custom_components/sksoft_dimmer_engine/
+   ```
+3. Restart Home Assistant
+4. Go to **Settings → Devices & Services → Add Integration**
+5. Search for **SKSoft Dimmer Engine** and click to add it
 
 ## Services
 
@@ -54,49 +62,56 @@ Stop the dimmer engine for one or more lights.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| lights | list | Yes | List of light entity IDs to stop cycling |
+| lights | list | Yes | List of light entity IDs to stop |
 
 ### sksoft_dimmer_engine.stop_all
 
-Stop the dimmer engine for all active lights. No parameters required.
+Stop the dimmer engine for all currently registered lights.
 
-### sksoft_dimmer_engine.status
-
-Log the current state of all active dimmer engine entries. No parameters required.
+No fields required.
 
 ### sksoft_dimmer_engine.start_ccw
 
-Start color temperature (CCW) cycling for one or more lights using a sine wave pattern.
+Start color temperature (CCW) cycling for one or more lights.
 
 | Field | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | lights | list | Yes | - | List of light entity IDs to cycle |
-| period_s | float | No | 10 | Duration of one complete color temperature cycle in seconds |
-| tick_s | float | No | 0.25 | How often to update color temperature in seconds |
-| min_color_temp | int | No | 2700 | Minimum color temperature in Kelvin (warm white) |
-| max_color_temp | int | No | 6500 | Maximum color temperature in Kelvin (cool white) |
+| period_s | float | No | 60 | Duration of one complete color temperature cycle in seconds |
+| tick_s | float | No | 0.5 | How often to update color temperature in seconds |
+| min_color_temp | int | No | 2700 | Minimum color temperature in Kelvin |
+| max_color_temp | int | No | 5000 | Maximum color temperature in Kelvin |
 | phase_mode | string | No | sync_to_current | Phase calculation mode: sync_to_current, absolute, relative |
 | phase_offset | float | No | 0 | Phase offset in radians |
-| sync_group | boolean | No | true | Sync all lights to first light's phase (when using sync_to_current) |
-| min_delta | int | No | 1 | Minimum color temperature change (in Kelvin) required before updating |
+| min_delta | int | No | 10 | Minimum color temperature change required before updating |
 
 ### sksoft_dimmer_engine.stop_ccw
 
-Stop color temperature (CCW) cycling for one or more lights.
+Stop color temperature cycling for one or more lights.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| lights | list | Yes | List of light entity IDs to stop CCW cycling |
+| lights | list | Yes | List of light entity IDs to stop |
 
 ### sksoft_dimmer_engine.stop_all_ccw
 
-Stop color temperature (CCW) cycling for all active lights. No parameters required.
+Stop color temperature cycling for all currently registered lights.
+
+No fields required.
+
+### sksoft_dimmer_engine.status
+
+Log the current status of the dimmer engine (active lights, cycle parameters) to the Home Assistant log at INFO level.
+
+No fields required.
 
 ## Conditions
 
+This integration provides native conditions for use in automations and scripts. These use the modern HA conditions framework (requires HA 2024.12+).
+
 ### is_cycle_dimming
 
-Check if any of the specified light entities are currently in cycle dimming. Returns true if at least one light is in cycle dimming.
+Check if any of the specified light entities are currently in brightness cycle dimming. Returns `true` if at least one light is actively cycling.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -113,18 +128,19 @@ automation:
         to: "on"
     condition:
       - condition: sksoft_dimmer_engine.is_cycle_dimming
-        lights:
-          - light.living_room
-          - light.bedroom
+        options:
+          lights:
+            - light.living_room
+            - light.bedroom
     action:
-      - service: notify.notify
+      - action: notify.notify
         data:
           message: "Lights are currently in cycle dimming mode!"
 ```
 
 ### is_ccw_cycling
 
-Check if any of the specified light entities are currently in color temperature (CCW) cycling. Returns true if at least one light is in CCW cycling.
+Check if any of the specified light entities are currently in color temperature (CCW) cycling. Returns `true` if at least one light is in CCW cycling.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -141,14 +157,17 @@ automation:
         to: "on"
     condition:
       - condition: sksoft_dimmer_engine.is_ccw_cycling
-        lights:
-          - light.living_room
-          - light.bedroom
+        options:
+          lights:
+            - light.living_room
+            - light.bedroom
     action:
-      - service: notify.notify
+      - action: notify.notify
         data:
           message: "Lights are currently in CCW cycling mode!"
 ```
+
+> **Note on condition syntax**: As of v2.0.0, conditions use the `options:` key to pass parameters, matching the HA 2024.12+ conditions framework. The old flat syntax (e.g., `lights:` directly under `condition:`) is no longer supported.
 
 ## Phase Modes
 
@@ -170,56 +189,56 @@ Adds the `phase_offset` value to the time-based phase. Useful for creating light
 
 ```yaml
 automation:
-  - alias: "Start Living Room Ambient Light"
+  - alias: "Start Dimming at Sunset"
     trigger:
       - platform: sun
         event: sunset
     action:
-      - service: sksoft_dimmer_engine.start
+      - action: sksoft_dimmer_engine.start
         data:
           lights:
             - light.living_room
-            - light.dining_room
           period_s: 30
-          min_brightness: 50
+          min_brightness: 10
           max_brightness: 200
 ```
 
-### Stop Cycling
+### Stop Cycling When Leaving Home
 
 ```yaml
 automation:
-  - alias: "Stop Ambient Light at Midnight"
+  - alias: "Stop All Dimming When Away"
     trigger:
-      - platform: time
-        at: "00:00:00"
+      - platform: state
+        entity_id: person.me
+        to: "not_home"
     action:
-      - service: sksoft_dimmer_engine.stop
-        data:
-          lights:
-            - light.living_room
-            - light.dining_room
+      - action: sksoft_dimmer_engine.stop_all
 ```
 
-### Slow Breathing Effect
+### Conditional Action - Only Notify When Not Cycling
 
 ```yaml
-script:
-  breathing_effect:
-    alias: "Breathing Light Effect"
-    sequence:
-      - service: sksoft_dimmer_engine.start
+automation:
+  - alias: "Notify only when lights are not cycling"
+    trigger:
+      - platform: state
+        entity_id: input_boolean.movie_mode
+        to: "on"
+    condition:
+      - condition: not
+        conditions:
+          - condition: sksoft_dimmer_engine.is_cycle_dimming
+            options:
+              lights:
+                - light.living_room
+    action:
+      - action: notify.notify
         data:
-          lights:
-            - light.bedroom
-          period_s: 8
-          tick_s: 0.1
-          min_brightness: 20
-          max_brightness: 180
-          phase_mode: sync_to_current
+          message: "Movie mode activated — lights are steady."
 ```
 
-### Multiple Lights with Phase Offset
+### Wave Effect with Multiple Lights
 
 ```yaml
 script:
@@ -227,7 +246,7 @@ script:
     alias: "Wave Light Effect"
     sequence:
       # Start first light
-      - service: sksoft_dimmer_engine.start
+      - action: sksoft_dimmer_engine.start
         data:
           lights:
             - light.lamp_1
@@ -235,7 +254,7 @@ script:
           phase_mode: absolute
           phase_offset: 0
       # Start second light with offset
-      - service: sksoft_dimmer_engine.start
+      - action: sksoft_dimmer_engine.start
         data:
           lights:
             - light.lamp_2
@@ -243,7 +262,7 @@ script:
           phase_mode: absolute
           phase_offset: 1.57  # pi/2 = 90 degrees behind
       # Start third light with offset
-      - service: sksoft_dimmer_engine.start
+      - action: sksoft_dimmer_engine.start
         data:
           lights:
             - light.lamp_3
@@ -259,23 +278,10 @@ script:
   check_dimmer_status:
     alias: "Check Dimmer Engine Status"
     sequence:
-      - service: sksoft_dimmer_engine.status
+      - action: sksoft_dimmer_engine.status
 ```
 
 The status will be logged to the Home Assistant log at INFO level.
-
-### Stop All Lights
-
-```yaml
-automation:
-  - alias: "Stop All Dimming When Away"
-    trigger:
-      - platform: state
-        entity_id: person.me
-        to: "not_home"
-    action:
-      - service: sksoft_dimmer_engine.stop_all
-```
 
 ### Color Temperature Cycling
 
@@ -284,7 +290,7 @@ script:
   color_temp_cycle:
     alias: "Color Temperature Cycle Effect"
     sequence:
-      - service: sksoft_dimmer_engine.start_ccw
+      - action: sksoft_dimmer_engine.start_ccw
         data:
           lights:
             - light.living_room
@@ -294,7 +300,7 @@ script:
           phase_mode: sync_to_current
 ```
 
-### Stop CCW Cycling
+### Stop CCW Cycling at Night
 
 ```yaml
 automation:
@@ -303,7 +309,7 @@ automation:
       - platform: time
         at: "22:00:00"
     action:
-      - service: sksoft_dimmer_engine.stop_all_ccw
+      - action: sksoft_dimmer_engine.stop_all_ccw
 ```
 
 ## Behavior Notes
@@ -356,18 +362,43 @@ If you see "Config flow could not be loaded: Invalid handler specified" when try
 
 2. **Restart Home Assistant** to apply the logging configuration.
 
-3. **Check the logs** by navigating to Settings → System → Logs, or by checking the `home-assistant.log` file in your config directory.
+3. **Check the logs** by navigating to **Settings → System → Logs**, or by checking the `home-assistant.log` file in your config directory.
 
 4. **Look for these log entries** to identify the issue:
-   - `SKSoft Dimmer Engine config_flow module loaded` - Confirms the config_flow module is being loaded
-   - `async_step_user called` - Confirms the config flow is being initiated
+   - `SKSoft Dimmer Engine config_flow module loaded` — Confirms the config_flow module is being loaded
+   - `async_step_user called` — Confirms the config flow is being initiated
    - Any error messages from `homeassistant.loader` about the integration
 
 5. **Common causes and solutions**:
    - **Integration not properly installed**: Ensure the `sksoft_dimmer_engine` folder is in your `custom_components` directory with all required files
-   - **Missing files**: Verify all files exist: `__init__.py`, `config_flow.py`, `const.py`, `manifest.json`, `strings.json`, and `translations/en.json`
+   - **Missing files**: Verify all files exist: `__init__.py`, `condition.py`, `conditions.yaml`, `config_flow.py`, `const.py`, `manifest.json`, `services.yaml`, `storage.py`, `strings.json`, and `translations/en.json`
    - **Cache issues**: Try restarting Home Assistant twice, or clear the browser cache
    - **Syntax errors**: Check the logs for Python syntax errors in the integration files
+
+### Condition Not Working / "Unknown condition" Error
+
+If a condition like `sksoft_dimmer_engine.is_cycle_dimming` fails with an unknown condition error:
+
+1. **Check your HA version**: This integration requires **Home Assistant 2024.12 or later**. Upgrade if needed.
+
+2. **Verify the `options:` key is present**: As of v2.0.0, condition parameters must be nested under `options:`:
+
+   ```yaml
+   # ✅ Correct (v2.0.0+)
+   condition:
+     - condition: sksoft_dimmer_engine.is_cycle_dimming
+       options:
+         lights:
+           - light.living_room
+
+   # ❌ Old syntax (no longer supported)
+   condition:
+     - condition: sksoft_dimmer_engine.is_cycle_dimming
+       lights:
+         - light.living_room
+   ```
+
+3. **Restart Home Assistant** after updating the integration to ensure the new condition classes are loaded.
 
 ### Checking Installed Files
 
@@ -377,6 +408,8 @@ To verify the integration is properly installed, check that these files exist in
 custom_components/
   sksoft_dimmer_engine/
     __init__.py
+    condition.py
+    conditions.yaml
     config_flow.py
     const.py
     manifest.json
@@ -387,15 +420,18 @@ custom_components/
       en.json
 ```
 
-### Collecting Debug Information
+### Lights Not Updating
 
-When reporting issues, please include:
+If lights are registered but not updating:
 
-1. Your Home Assistant version
-2. The contents of `manifest.json` (to verify the version)
-3. Relevant log entries from `home-assistant.log` with debug logging enabled
-4. How you installed the integration (HACS or manual)
+- Check that the light entities are **currently on** — the engine skips lights that are off
+- Verify `tick_s` is not set too low (below 0.1 may cause issues on slower hardware)
+- Check the logs for `WARNING` messages about entity not found
 
-## License
+### Persistence Not Restoring
 
-This project is licensed under the MIT License
+If the registry is not restored after a restart:
+
+- Check that Home Assistant has write access to its `.storage` directory
+- Look for errors in the log related to `sksoft_dimmer_engine` storage
+- The storage file is located at `<config>/.storage/sksoft_dimmer_engine`

--- a/custom_components/sksoft_dimmer_engine/__init__.py
+++ b/custom_components/sksoft_dimmer_engine/__init__.py
@@ -75,7 +75,7 @@ class DimmerEngineData(TypedDict):
 type DimmerEngineConfigEntry = ConfigEntry[DimmerEngineData]
 
 
-def _validate_brightness_range(data: dict) -> dict:
+def _validate_brightness_range(data: dict[str, Any]) -> dict[str, Any]:
     """Validate that min_brightness is less than max_brightness."""
     min_b = data.get(ATTR_MIN_BRIGHTNESS, DEFAULT_MIN_BRIGHTNESS)
     max_b = data.get(ATTR_MAX_BRIGHTNESS, DEFAULT_MAX_BRIGHTNESS)
@@ -123,7 +123,7 @@ SERVICE_STOP_SCHEMA = vol.Schema(
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
-def _validate_color_temp_range(data: dict) -> dict:
+def _validate_color_temp_range(data: dict[str, Any]) -> dict[str, Any]:
     """Validate that min_color_temp is less than max_color_temp."""
     min_ct = data.get(ATTR_MIN_COLOR_TEMP, DEFAULT_MIN_COLOR_TEMP)
     max_ct = data.get(ATTR_MAX_COLOR_TEMP, DEFAULT_MAX_COLOR_TEMP)
@@ -163,7 +163,9 @@ SERVICE_START_CCW_SCHEMA = vol.All(
 )
 
 
-def _get_engines(hass: HomeAssistant) -> tuple[DimmerEngine | None, CCWCycleEngine | None]:
+def _get_engines(
+    hass: HomeAssistant,
+) -> tuple[DimmerEngine | None, CCWCycleEngine | None]:
     """Return ``(engine, ccw_engine)`` from the (single) loaded config entry.
 
     Returns ``(None, None)`` when no config entry is loaded yet — service calls

--- a/custom_components/sksoft_dimmer_engine/__init__.py
+++ b/custom_components/sksoft_dimmer_engine/__init__.py
@@ -1,34 +1,28 @@
 """SKSoft Dimmer Engine integration for Home Assistant.
 
 This integration provides a sine-wave, time-based brightness cycling engine
-for one or more Light entities, running a single shared async loop.
+for one or more Light entities, running a single shared async loop, plus a
+parallel CCW (color temperature) cycling engine.
+
+Module layout:
+- ``engine.py``     : :class:`DimmerEngine` (brightness cycling)
+- ``ccw_engine.py`` : :class:`CCWCycleEngine` (color temperature cycling)
+- ``__init__.py``   : setup/teardown, service registration, runtime_data wiring
 """
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import math
-from time import monotonic
-from typing import TYPE_CHECKING, Any
+from typing import Any, TypedDict
 
 import voluptuous as vol
 
-from homeassistant import config_entries
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP_KELVIN,
-    ATTR_TRANSITION,
-)
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    SERVICE_TURN_ON,
-    STATE_ON,
-)
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
+from .ccw_engine import CCWCycleEngine
 from .const import (
     ATTR_LIGHTS,
     ATTR_MAX_BRIGHTNESS,
@@ -52,20 +46,7 @@ from .const import (
     DEFAULT_SYNC_GROUP,
     DEFAULT_TICK_S,
     DOMAIN,
-    PHASE_MODE_ABSOLUTE,
-    PHASE_MODE_SYNC_TO_CURRENT,
     PHASE_MODES,
-    REG_MAX_B,
-    REG_MAX_CT,
-    REG_MIN_B,
-    REG_MIN_CT,
-    REG_MIN_DELTA,
-    REG_PERIOD,
-    REG_PHASE_MODE,
-    REG_PHASE_OFFSET,
-    REG_STARTED_AT_TS,
-    REG_SYNC_GROUP,
-    REG_TICK,
     SERVICE_START,
     SERVICE_START_CCW,
     SERVICE_STATUS,
@@ -74,15 +55,24 @@ from .const import (
     SERVICE_STOP_ALL_CCW,
     SERVICE_STOP_CCW,
 )
-from .storage import CCWCycleStore, DimmerEngineStore
-
-if TYPE_CHECKING:
-    pass
+from .engine import DimmerEngine
 
 LOGGER = logging.getLogger(__name__)
 
 # Log at module load time to help debug integration loading issues
 LOGGER.debug("SKSoft Dimmer Engine __init__ module loaded, DOMAIN=%s", DOMAIN)
+
+
+class DimmerEngineData(TypedDict):
+    """Runtime data attached to the config entry."""
+
+    engine: DimmerEngine
+    ccw_engine: CCWCycleEngine
+
+
+# Typed alias for our config entry — its ``runtime_data`` is a
+# :class:`DimmerEngineData` once :func:`async_setup_entry` has run.
+type DimmerEngineConfigEntry = ConfigEntry[DimmerEngineData]
 
 
 def _validate_brightness_range(data: dict) -> dict:
@@ -165,7 +155,7 @@ SERVICE_START_CCW_SCHEMA = vol.All(
             ),
             vol.Optional(ATTR_SYNC_GROUP, default=DEFAULT_SYNC_GROUP): cv.boolean,
             vol.Optional(ATTR_MIN_DELTA, default=DEFAULT_MIN_DELTA): vol.All(
-                vol.Coerce(int), vol.Range(min=1, max=200)
+                vol.Coerce(int), vol.Range(min=1, max=255)
             ),
         }
     ),
@@ -173,683 +163,34 @@ SERVICE_START_CCW_SCHEMA = vol.All(
 )
 
 
-class DimmerEngine:
-    """Class to manage the dimmer engine loop and registry."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the dimmer engine."""
-        self.hass = hass
-        self._registry: dict[str, dict[str, Any]] = {}
-        self._lock = asyncio.Lock()
-        self._task: asyncio.Task | None = None
-        self._store = DimmerEngineStore(hass)
-        self._running = False
-
-    async def async_load(self) -> None:
-        """Load registry from storage and start loop if needed."""
-        async with self._lock:
-            self._registry = await self._store.async_load()
-            if self._registry:
-                LOGGER.info(
-                    "Restored %d lights from storage: %s",
-                    len(self._registry),
-                    list(self._registry.keys()),
-                )
-                self._ensure_loop_running()
-
-    async def async_save(self) -> None:
-        """Save registry to storage."""
-        await self._store.async_save(self._registry)
-
-    async def async_shutdown(self) -> None:
-        """Shutdown the engine cleanly."""
-        async with self._lock:
-            self._running = False
-            if self._task and not self._task.done():
-                self._task.cancel()
-                try:
-                    await self._task
-                except asyncio.CancelledError:
-                    pass
-            await self.async_save()
-            LOGGER.info("Dimmer engine shutdown complete")
-
-    def _compute_phase_offset_for_brightness(
-        self, current_brightness: int, min_b: int, max_b: int, period: float
-    ) -> float:
-        """Compute phase offset so sine matches current brightness at t=0."""
-        mid = (min_b + max_b) / 2
-        amp = (max_b - min_b) / 2
-
-        if amp == 0:
-            return 0.0
-
-        # Clamp to valid range for asin
-        normalized = (current_brightness - mid) / amp
-        normalized = max(-1.0, min(1.0, normalized))
-
-        # asin gives us the phase where sin(phase) = normalized
-        # We want the phase at t=0, so offset = asin(normalized)
-        return math.asin(normalized)
-
-    async def async_start(
-        self,
-        lights: list[str],
-        period_s: float,
-        tick_s: float,
-        min_brightness: int,
-        max_brightness: int,
-        phase_mode: str,
-        phase_offset: float,
-        sync_group: bool,
-        min_delta: int,
-    ) -> None:
-        """Start dimming for the specified lights."""
-        async with self._lock:
-            now = monotonic()
-            computed_offset: float | None = None
-
-            for i, entity_id in enumerate(lights):
-                # Determine phase offset based on mode
-                if phase_mode == PHASE_MODE_SYNC_TO_CURRENT:
-                    if sync_group and computed_offset is not None:
-                        # Reuse computed offset from first light
-                        offset = computed_offset
-                    else:
-                        # Compute offset from current brightness
-                        state = self.hass.states.get(entity_id)
-                        current_brightness = DEFAULT_MIN_BRIGHTNESS
-                        if state and state.attributes.get(ATTR_BRIGHTNESS):
-                            current_brightness = int(
-                                state.attributes.get(ATTR_BRIGHTNESS)
-                            )
-                        offset = self._compute_phase_offset_for_brightness(
-                            current_brightness,
-                            min_brightness,
-                            max_brightness,
-                            period_s,
-                        )
-                        if sync_group and i == 0:
-                            computed_offset = offset
-                elif phase_mode == PHASE_MODE_ABSOLUTE:
-                    offset = phase_offset
-                else:  # PHASE_MODE_RELATIVE
-                    offset = phase_offset
-
-                self._registry[entity_id] = {
-                    REG_PERIOD: period_s,
-                    REG_TICK: tick_s,
-                    REG_MIN_B: min_brightness,
-                    REG_MAX_B: max_brightness,
-                    REG_PHASE_OFFSET: offset,
-                    REG_MIN_DELTA: min_delta,
-                    REG_STARTED_AT_TS: now,
-                    REG_PHASE_MODE: phase_mode,
-                    REG_SYNC_GROUP: sync_group,
-                }
-                LOGGER.info(
-                    "Started dimmer engine for %s: period=%.2fs, brightness=[%d,%d], "
-                    "phase_mode=%s, offset=%.4f",
-                    entity_id,
-                    period_s,
-                    min_brightness,
-                    max_brightness,
-                    phase_mode,
-                    offset,
-                )
-
-            await self.async_save()
-            self._ensure_loop_running()
-
-    async def async_stop(self, lights: list[str]) -> None:
-        """Stop dimming for the specified lights."""
-        async with self._lock:
-            for entity_id in lights:
-                if entity_id in self._registry:
-                    del self._registry[entity_id]
-                    LOGGER.info("Stopped dimmer engine for %s", entity_id)
-                else:
-                    LOGGER.warning(
-                        "Light %s was not in dimmer engine registry", entity_id
-                    )
-
-            await self.async_save()
-
-            # Stop the loop immediately if registry is now empty
-            if not self._registry:
-                self._stop_loop()
-
-    async def async_stop_all(self) -> None:
-        """Stop dimming for all lights."""
-        async with self._lock:
-            count = len(self._registry)
-            self._registry.clear()
-            await self.async_save()
-            LOGGER.info("Stopped dimmer engine for all %d lights", count)
-
-            # Stop the loop immediately
-            self._stop_loop()
-
-    def _stop_loop(self) -> None:
-        """Stop the background loop task."""
-        self._running = False
-        if self._task and not self._task.done():
-            self._task.cancel()
-            LOGGER.debug("Cancelled dimmer engine loop task")
-
-    def get_status(self) -> dict[str, Any]:
-        """Get the current registry status."""
-        return {
-            "active_lights": len(self._registry),
-            "loop_running": self._task is not None and not self._task.done(),
-            "registry": {k: dict(v) for k, v in self._registry.items()},
-        }
-
-    def is_cycle_dimming(self, entity_ids: list[str]) -> bool:
-        """Check if any of the given light entities are in cycle dimming.
-
-        Args:
-            entity_ids: List of entity IDs to check.
-
-        Returns:
-            True if at least one of the entities is currently in cycle dimming.
-
-        """
-        for entity_id in entity_ids:
-            if entity_id in self._registry:
-                LOGGER.debug("Entity %s is in cycle dimming", entity_id)
-                return True
-        LOGGER.debug("No entities in cycle dimming from: %s", entity_ids)
-        return False
-
-    @callback
-    def _ensure_loop_running(self) -> None:
-        """Ensure the background loop task is running."""
-        if self._task is None or self._task.done():
-            self._running = True
-            self._task = self.hass.async_create_task(
-                self._run_loop(), "sksoft_dimmer_engine_loop"
-            )
-            LOGGER.debug("Started dimmer engine loop task")
-
-    async def _run_loop(self) -> None:
-        """Main loop that updates all lights."""
-        LOGGER.debug("Dimmer engine loop started")
-
-        while self._running:
-            # Collect registry snapshot and min tick while holding the lock
-            async with self._lock:
-                if not self._registry:
-                    LOGGER.debug("Registry empty, stopping loop")
-                    break
-
-                # Find the minimum tick interval
-                min_tick = min(
-                    entry[REG_TICK] for entry in self._registry.values()
-                )
-
-                # Take a snapshot of the registry to avoid holding lock during updates
-                registry_snapshot = {k: dict(v) for k, v in self._registry.items()}
-
-            # Get current time after releasing lock (monotonic for accurate timing)
-            now = monotonic()
-
-            # Build update coroutines for all lights and execute in parallel
-            update_tasks = [
-                self._update_light(entity_id, entry, now)
-                for entity_id, entry in registry_snapshot.items()
-            ]
-            if update_tasks:
-                results = await asyncio.gather(*update_tasks)
-                # Collect entities that need to be removed (missing entities)
-                entities_to_remove = [r for r in results if r is not None]
-
-                # Remove missing entities from registry while holding the lock
-                if entities_to_remove:
-                    async with self._lock:
-                        for entity_id in entities_to_remove:
-                            if self._registry.pop(entity_id, None) is not None:
-                                LOGGER.info("Removed missing entity %s from registry", entity_id)
-                        await self.async_save()
-
-            # Sleep for the minimum tick interval
-            await asyncio.sleep(min_tick)
-
-        LOGGER.debug("Dimmer engine loop ended")
-
-    async def _update_light(
-        self, entity_id: str, entry: dict[str, Any], now: float
-    ) -> str | None:
-        """Update a single light's brightness.
-
-        Returns the entity_id if the entity was not found and should be removed,
-        otherwise returns None.
-        """
-        period = entry[REG_PERIOD]
-        min_b = entry[REG_MIN_B]
-        max_b = entry[REG_MAX_B]
-        phase_offset = entry[REG_PHASE_OFFSET]
-        min_delta = entry[REG_MIN_DELTA]
-        started_at = entry[REG_STARTED_AT_TS]
-
-        # Calculate elapsed time
-        elapsed = now - started_at
-
-        # Calculate phase
-        time_phase = (2 * math.pi * elapsed) / period
-
-        # All phase modes use the same formula: phase = time_phase + offset
-        # The difference is how the offset was computed when the light was registered:
-        # - sync_to_current: offset computed from current brightness using asin
-        # - absolute: offset provided directly by user
-        # - relative: offset provided by user, added to time-based phase
-        phase = time_phase + phase_offset
-
-        # Calculate target brightness using sine wave
-        mid = (min_b + max_b) / 2
-        amp = (max_b - min_b) / 2
-        target = round(mid + amp * math.sin(phase))
-
-        # Clamp to valid range
-        target = max(min_b, min(max_b, target))
-
-        # Get current state
-        state = self.hass.states.get(entity_id)
-        if state is None:
-            LOGGER.warning("Entity %s not found, will remove from registry", entity_id)
-            return entity_id
-
-        # Skip lights that are not currently on
-        if state.state != STATE_ON:
-            LOGGER.debug("Skipping %s: light is not on (state=%s)", entity_id, state.state)
-            return None
-
-        current_brightness = state.attributes.get(ATTR_BRIGHTNESS, 0)
-        if current_brightness is None:
-            current_brightness = 0
-
-        # Only update if delta is significant enough
-        if abs(target - current_brightness) >= min_delta:
-            LOGGER.debug(
-                "Updating %s: brightness %d -> %d (phase=%.2f)",
-                entity_id,
-                current_brightness,
-                target,
-                phase,
-            )
-            # Use transition time (in seconds) equal to tick interval for smooth dimming
-            tick = entry[REG_TICK]
-            await self.hass.services.async_call(
-                "light",
-                SERVICE_TURN_ON,
-                {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: target, ATTR_TRANSITION: tick},
-                blocking=False,
-            )
-
-        return None
-
-
-class CCWCycleEngine:
-    """Class to manage the CCW (Color Temperature) cycle engine loop and registry."""
-
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the CCW cycle engine."""
-        self.hass = hass
-        self._registry: dict[str, dict[str, Any]] = {}
-        self._lock = asyncio.Lock()
-        self._task: asyncio.Task | None = None
-        self._store = CCWCycleStore(hass)
-        self._running = False
-
-    async def async_load(self) -> None:
-        """Load registry from storage and start loop if needed."""
-        async with self._lock:
-            self._registry = await self._store.async_load()
-            if self._registry:
-                LOGGER.info(
-                    "Restored %d lights from CCW storage: %s",
-                    len(self._registry),
-                    list(self._registry.keys()),
-                )
-                self._ensure_loop_running()
-
-    async def async_save(self) -> None:
-        """Save registry to storage."""
-        await self._store.async_save(self._registry)
-
-    async def async_shutdown(self) -> None:
-        """Shutdown the engine cleanly."""
-        async with self._lock:
-            self._running = False
-            if self._task and not self._task.done():
-                self._task.cancel()
-                try:
-                    await self._task
-                except asyncio.CancelledError:
-                    pass
-            await self.async_save()
-            LOGGER.info("CCW cycle engine shutdown complete")
-
-    def _compute_phase_offset_for_color_temp(
-        self, current_ct: int, min_ct: int, max_ct: int, period: float
-    ) -> float:
-        """Compute phase offset so sine matches current color temp at t=0."""
-        mid = (min_ct + max_ct) / 2
-        amp = (max_ct - min_ct) / 2
-
-        if amp == 0:
-            return 0.0
-
-        # Clamp to valid range for asin
-        normalized = (current_ct - mid) / amp
-        normalized = max(-1.0, min(1.0, normalized))
-
-        # asin gives us the phase where sin(phase) = normalized
-        # We want the phase at t=0, so offset = asin(normalized)
-        return math.asin(normalized)
-
-    async def async_start(
-        self,
-        lights: list[str],
-        period_s: float,
-        tick_s: float,
-        min_color_temp: int,
-        max_color_temp: int,
-        phase_mode: str,
-        phase_offset: float,
-        sync_group: bool,
-        min_delta: int,
-    ) -> None:
-        """Start CCW cycling for the specified lights."""
-        async with self._lock:
-            now = monotonic()
-            computed_offset: float | None = None
-
-            for i, entity_id in enumerate(lights):
-                # Determine phase offset based on mode
-                if phase_mode == PHASE_MODE_SYNC_TO_CURRENT:
-                    if sync_group and computed_offset is not None:
-                        # Reuse computed offset from first light
-                        offset = computed_offset
-                    else:
-                        # Compute offset from current color temperature
-                        state = self.hass.states.get(entity_id)
-                        current_ct = DEFAULT_MIN_COLOR_TEMP
-                        if state and state.attributes.get(ATTR_COLOR_TEMP_KELVIN):
-                            current_ct = int(
-                                state.attributes.get(ATTR_COLOR_TEMP_KELVIN)
-                            )
-                        offset = self._compute_phase_offset_for_color_temp(
-                            current_ct,
-                            min_color_temp,
-                            max_color_temp,
-                            period_s,
-                        )
-                        if sync_group and i == 0:
-                            computed_offset = offset
-                elif phase_mode == PHASE_MODE_ABSOLUTE:
-                    offset = phase_offset
-                else:  # PHASE_MODE_RELATIVE
-                    offset = phase_offset
-
-                self._registry[entity_id] = {
-                    REG_PERIOD: period_s,
-                    REG_TICK: tick_s,
-                    REG_MIN_CT: min_color_temp,
-                    REG_MAX_CT: max_color_temp,
-                    REG_PHASE_OFFSET: offset,
-                    REG_MIN_DELTA: min_delta,
-                    REG_STARTED_AT_TS: now,
-                    REG_PHASE_MODE: phase_mode,
-                    REG_SYNC_GROUP: sync_group,
-                }
-                LOGGER.info(
-                    "Started CCW cycle engine for %s: period=%.2fs, color_temp=[%d,%d], "
-                    "phase_mode=%s, offset=%.4f",
-                    entity_id,
-                    period_s,
-                    min_color_temp,
-                    max_color_temp,
-                    phase_mode,
-                    offset,
-                )
-
-            await self.async_save()
-            self._ensure_loop_running()
-
-    async def async_stop(self, lights: list[str]) -> None:
-        """Stop CCW cycling for the specified lights."""
-        async with self._lock:
-            for entity_id in lights:
-                if entity_id in self._registry:
-                    del self._registry[entity_id]
-                    LOGGER.info("Stopped CCW cycle engine for %s", entity_id)
-                else:
-                    LOGGER.warning(
-                        "Light %s was not in CCW cycle engine registry", entity_id
-                    )
-
-            await self.async_save()
-
-            # Stop the loop immediately if registry is now empty
-            if not self._registry:
-                self._stop_loop()
-
-    async def async_stop_all(self) -> None:
-        """Stop CCW cycling for all lights."""
-        async with self._lock:
-            count = len(self._registry)
-            self._registry.clear()
-            await self.async_save()
-            LOGGER.info("Stopped CCW cycle engine for all %d lights", count)
-
-            # Stop the loop immediately
-            self._stop_loop()
-
-    def _stop_loop(self) -> None:
-        """Stop the background loop task."""
-        self._running = False
-        if self._task and not self._task.done():
-            self._task.cancel()
-            LOGGER.debug("Cancelled CCW cycle engine loop task")
-
-    def get_status(self) -> dict[str, Any]:
-        """Get the current registry status."""
-        return {
-            "active_lights": len(self._registry),
-            "loop_running": self._task is not None and not self._task.done(),
-            "registry": {k: dict(v) for k, v in self._registry.items()},
-        }
-
-    def is_ccw_cycling(self, entity_ids: list[str]) -> bool:
-        """Check if any of the given light entities are in CCW cycling.
-
-        Args:
-            entity_ids: List of entity IDs to check.
-
-        Returns:
-            True if at least one of the entities is currently in CCW cycling.
-
-        """
-        for entity_id in entity_ids:
-            if entity_id in self._registry:
-                LOGGER.debug("Entity %s is in CCW cycling", entity_id)
-                return True
-        LOGGER.debug("No entities in CCW cycling from: %s", entity_ids)
-        return False
-
-    @callback
-    def _ensure_loop_running(self) -> None:
-        """Ensure the background loop task is running."""
-        if self._task is None or self._task.done():
-            self._running = True
-            self._task = self.hass.async_create_task(
-                self._run_loop(), "sksoft_ccw_cycle_engine_loop"
-            )
-            LOGGER.debug("Started CCW cycle engine loop task")
-
-    async def _run_loop(self) -> None:
-        """Main loop that updates all lights."""
-        LOGGER.debug("CCW cycle engine loop started")
-
-        while self._running:
-            # Collect registry snapshot and min tick while holding the lock
-            async with self._lock:
-                if not self._registry:
-                    LOGGER.debug("CCW registry empty, stopping loop")
-                    break
-
-                # Find the minimum tick interval
-                min_tick = min(
-                    entry[REG_TICK] for entry in self._registry.values()
-                )
-
-                # Take a snapshot of the registry to avoid holding lock during updates
-                registry_snapshot = {k: dict(v) for k, v in self._registry.items()}
-
-            # Get current time after releasing lock (monotonic for accurate timing)
-            now = monotonic()
-
-            # Build update coroutines for all lights and execute in parallel
-            update_tasks = [
-                self._update_light(entity_id, entry, now)
-                for entity_id, entry in registry_snapshot.items()
-            ]
-            if update_tasks:
-                results = await asyncio.gather(*update_tasks)
-                # Collect entities that need to be removed (missing entities)
-                entities_to_remove = [r for r in results if r is not None]
-
-                # Remove missing entities from registry while holding the lock
-                if entities_to_remove:
-                    async with self._lock:
-                        for entity_id in entities_to_remove:
-                            if self._registry.pop(entity_id, None) is not None:
-                                LOGGER.info(
-                                    "Removed missing entity %s from CCW registry",
-                                    entity_id,
-                                )
-                        await self.async_save()
-
-            # Sleep for the minimum tick interval
-            await asyncio.sleep(min_tick)
-
-        LOGGER.debug("CCW cycle engine loop ended")
-
-    async def _update_light(
-        self, entity_id: str, entry: dict[str, Any], now: float
-    ) -> str | None:
-        """Update a single light's color temperature.
-
-        Returns the entity_id if the entity was not found and should be removed,
-        otherwise returns None.
-        """
-        period = entry[REG_PERIOD]
-        min_ct = entry[REG_MIN_CT]
-        max_ct = entry[REG_MAX_CT]
-        phase_offset = entry[REG_PHASE_OFFSET]
-        min_delta = entry[REG_MIN_DELTA]
-        started_at = entry[REG_STARTED_AT_TS]
-
-        # Calculate elapsed time
-        elapsed = now - started_at
-
-        # Calculate phase
-        time_phase = (2 * math.pi * elapsed) / period
-
-        # All phase modes use the same formula: phase = time_phase + offset
-        phase = time_phase + phase_offset
-
-        # Calculate target color temperature using sine wave
-        mid = (min_ct + max_ct) / 2
-        amp = (max_ct - min_ct) / 2
-        target = round(mid + amp * math.sin(phase))
-
-        # Clamp to valid range
-        target = max(min_ct, min(max_ct, target))
-
-        # Get current state
-        state = self.hass.states.get(entity_id)
-        if state is None:
-            LOGGER.warning(
-                "Entity %s not found, will remove from CCW registry", entity_id
-            )
-            return entity_id
-
-        # Skip lights that are not currently on
-        if state.state != STATE_ON:
-            LOGGER.debug(
-                "Skipping %s: light is not on (state=%s)", entity_id, state.state
-            )
-            return None
-
-        current_ct = state.attributes.get(ATTR_COLOR_TEMP_KELVIN) or 0
-
-        # Only update if delta is significant enough
-        if abs(target - current_ct) >= min_delta:
-            LOGGER.debug(
-                "Updating %s: color_temp %d -> %d (phase=%.2f)",
-                entity_id,
-                current_ct,
-                target,
-                phase,
-            )
-            # Use transition time (in seconds) equal to tick interval for smooth changes
-            tick = entry[REG_TICK]
-            await self.hass.services.async_call(
-                "light",
-                SERVICE_TURN_ON,
-                {
-                    ATTR_ENTITY_ID: entity_id,
-                    ATTR_COLOR_TEMP_KELVIN: target,
-                    ATTR_TRANSITION: tick,
-                },
-                blocking=False,
-            )
-
-        return None
+def _get_engines(hass: HomeAssistant) -> tuple[DimmerEngine | None, CCWCycleEngine | None]:
+    """Return ``(engine, ccw_engine)`` from the (single) loaded config entry.
+
+    Returns ``(None, None)`` when no config entry is loaded yet — service calls
+    in that window are no-ops with a warning.
+    """
+    entries = hass.config_entries.async_entries(DOMAIN)
+    for entry in entries:
+        data = getattr(entry, "runtime_data", None)
+        if data is not None:
+            return data["engine"], data["ccw_engine"]
+    return None, None
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the SKSoft Dimmer Engine integration.
 
-    This integration is configured via the UI (config flow) only.
-    This function is required for Home Assistant but does nothing.
+    Registers domain-scoped services exactly once. The engines themselves are
+    created per config entry in :func:`async_setup_entry` and exposed via
+    ``entry.runtime_data``.
     """
-    return True
 
-
-async def async_setup_entry(
-    hass: HomeAssistant, entry: config_entries.ConfigEntry
-) -> bool:
-    """Set up SKSoft Dimmer Engine from a config entry."""
-    # Initialize brightness dimmer engine
-    engine = DimmerEngine(hass)
-
-    # Initialize CCW (Color Temperature) cycle engine
-    ccw_engine = CCWCycleEngine(hass)
-
-    # Store both engines in hass.data
-    hass.data[DOMAIN] = {
-        "dimmer_engine": engine,
-        "ccw_engine": ccw_engine,
-    }
-
-    # Load persisted registries
-    await engine.async_load()
-    await ccw_engine.async_load()
-
-    # Register shutdown handler
-    async def async_shutdown_handler(event: Any) -> None:
-        """Handle shutdown."""
-        await engine.async_shutdown()
-        await ccw_engine.async_shutdown()
-
-    hass.bus.async_listen_once("homeassistant_stop", async_shutdown_handler)
-
-    # Register brightness dimmer services
     async def handle_start(call: ServiceCall) -> None:
         """Handle the start service call."""
+        engine, _ = _get_engines(hass)
+        if engine is None:
+            LOGGER.warning("sksoft_dimmer_engine.start called but no entry is loaded")
+            return
         await engine.async_start(
             lights=call.data[ATTR_LIGHTS],
             period_s=call.data[ATTR_PERIOD_S],
@@ -864,22 +205,39 @@ async def async_setup_entry(
 
     async def handle_stop(call: ServiceCall) -> None:
         """Handle the stop service call."""
+        engine, _ = _get_engines(hass)
+        if engine is None:
+            LOGGER.warning("sksoft_dimmer_engine.stop called but no entry is loaded")
+            return
         await engine.async_stop(lights=call.data[ATTR_LIGHTS])
 
     async def handle_stop_all(call: ServiceCall) -> None:
         """Handle the stop_all service call."""
+        engine, _ = _get_engines(hass)
+        if engine is None:
+            LOGGER.warning(
+                "sksoft_dimmer_engine.stop_all called but no entry is loaded"
+            )
+            return
         await engine.async_stop_all()
 
     async def handle_status(call: ServiceCall) -> None:
         """Handle the status service call."""
-        status = engine.get_status()
-        ccw_status = ccw_engine.get_status()
-        LOGGER.info("Dimmer Engine Status: %s", status)
-        LOGGER.info("CCW Cycle Engine Status: %s", ccw_status)
+        engine, ccw_engine = _get_engines(hass)
+        if engine is None or ccw_engine is None:
+            LOGGER.warning("sksoft_dimmer_engine.status called but no entry is loaded")
+            return
+        LOGGER.info("Dimmer Engine Status: %s", engine.get_status())
+        LOGGER.info("CCW Cycle Engine Status: %s", ccw_engine.get_status())
 
-    # Register CCW (Color Temperature) cycle services
     async def handle_start_ccw(call: ServiceCall) -> None:
         """Handle the start_ccw service call."""
+        _, ccw_engine = _get_engines(hass)
+        if ccw_engine is None:
+            LOGGER.warning(
+                "sksoft_dimmer_engine.start_ccw called but no entry is loaded"
+            )
+            return
         await ccw_engine.async_start(
             lights=call.data[ATTR_LIGHTS],
             period_s=call.data[ATTR_PERIOD_S],
@@ -894,12 +252,25 @@ async def async_setup_entry(
 
     async def handle_stop_ccw(call: ServiceCall) -> None:
         """Handle the stop_ccw service call."""
+        _, ccw_engine = _get_engines(hass)
+        if ccw_engine is None:
+            LOGGER.warning(
+                "sksoft_dimmer_engine.stop_ccw called but no entry is loaded"
+            )
+            return
         await ccw_engine.async_stop(lights=call.data[ATTR_LIGHTS])
 
     async def handle_stop_all_ccw(call: ServiceCall) -> None:
         """Handle the stop_all_ccw service call."""
+        _, ccw_engine = _get_engines(hass)
+        if ccw_engine is None:
+            LOGGER.warning(
+                "sksoft_dimmer_engine.stop_all_ccw called but no entry is loaded"
+            )
+            return
         await ccw_engine.async_stop_all()
 
+    # Register brightness dimmer services (idempotent — async_setup is one-time)
     hass.services.async_register(
         DOMAIN, SERVICE_START, handle_start, schema=SERVICE_START_SCHEMA
     )
@@ -918,33 +289,48 @@ async def async_setup_entry(
     )
     hass.services.async_register(DOMAIN, SERVICE_STOP_ALL_CCW, handle_stop_all_ccw)
 
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: DimmerEngineConfigEntry
+) -> bool:
+    """Set up SKSoft Dimmer Engine from a config entry."""
+    # Initialize brightness dimmer engine
+    engine = DimmerEngine(hass)
+    # Initialize CCW (Color Temperature) cycle engine
+    ccw_engine = CCWCycleEngine(hass)
+
+    # Store both engines on the entry's runtime_data (replaces hass.data[DOMAIN])
+    entry.runtime_data = DimmerEngineData(engine=engine, ccw_engine=ccw_engine)
+
+    # Load persisted registries
+    await engine.async_load()
+    await ccw_engine.async_load()
+
+    # Register shutdown handler tied to this entry
+    async def async_shutdown_handler(event: Any) -> None:
+        """Handle Home Assistant stop event."""
+        await engine.async_shutdown()
+        await ccw_engine.async_shutdown()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once("homeassistant_stop", async_shutdown_handler)
+    )
+
     LOGGER.info("SKSoft Dimmer Engine integration loaded")
     return True
 
 
 async def async_unload_entry(
-    hass: HomeAssistant, entry: config_entries.ConfigEntry
+    hass: HomeAssistant, entry: DimmerEngineConfigEntry
 ) -> bool:
     """Unload a config entry."""
-    data = hass.data.get(DOMAIN)
-    if data:
-        engine = data.get("dimmer_engine")
-        ccw_engine = data.get("ccw_engine")
-        if engine:
-            await engine.async_shutdown()
-        if ccw_engine:
-            await ccw_engine.async_shutdown()
+    data: DimmerEngineData | None = getattr(entry, "runtime_data", None)
+    if data is not None:
+        await data["engine"].async_shutdown()
+        await data["ccw_engine"].async_shutdown()
 
-    # Unregister services
-    hass.services.async_remove(DOMAIN, SERVICE_START)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP_ALL)
-    hass.services.async_remove(DOMAIN, SERVICE_STATUS)
-    hass.services.async_remove(DOMAIN, SERVICE_START_CCW)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP_CCW)
-    hass.services.async_remove(DOMAIN, SERVICE_STOP_ALL_CCW)
-
-    hass.data.pop(DOMAIN, None)
-
-    LOGGER.info("SKSoft Dimmer Engine integration unloaded")
+    # Services are owned by async_setup and survive entry reloads — do not
+    # unregister them here.
     return True

--- a/custom_components/sksoft_dimmer_engine/ccw_engine.py
+++ b/custom_components/sksoft_dimmer_engine/ccw_engine.py
@@ -7,20 +7,14 @@ that drives sine-wave color-temperature cycling for one or more Light entities.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
 from time import monotonic
 from typing import Any
 
-from homeassistant.components.light import (
-    ATTR_COLOR_TEMP_KELVIN,
-    ATTR_TRANSITION,
-)
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    SERVICE_TURN_ON,
-    STATE_ON,
-)
+from homeassistant.components.light import ATTR_COLOR_TEMP_KELVIN, ATTR_TRANSITION
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 
 from .const import (
@@ -50,7 +44,7 @@ class CCWCycleEngine:
         self.hass = hass
         self._registry: dict[str, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
-        self._task: asyncio.Task | None = None
+        self._task: asyncio.Task[None] | None = None
         self._store = CCWCycleStore(hass)
         self._running = False
 
@@ -76,10 +70,8 @@ class CCWCycleEngine:
             self._running = False
             if self._task and not self._task.done():
                 self._task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await self._task
-                except asyncio.CancelledError:
-                    pass
             await self.async_save()
             LOGGER.info("CCW cycle engine shutdown complete")
 
@@ -128,10 +120,10 @@ class CCWCycleEngine:
                         # Compute offset from current color temperature
                         state = self.hass.states.get(entity_id)
                         current_ct = DEFAULT_MIN_COLOR_TEMP
-                        if state and state.attributes.get(ATTR_COLOR_TEMP_KELVIN):
-                            current_ct = int(
-                                state.attributes.get(ATTR_COLOR_TEMP_KELVIN)
-                            )
+                        if state is not None:
+                            ct_attr = state.attributes.get(ATTR_COLOR_TEMP_KELVIN)
+                            if ct_attr is not None:
+                                current_ct = int(ct_attr)
                         offset = self._compute_phase_offset_for_color_temp(
                             current_ct,
                             min_color_temp,
@@ -242,7 +234,7 @@ class CCWCycleEngine:
             LOGGER.debug("Started CCW cycle engine loop task")
 
     async def _run_loop(self) -> None:
-        """Main loop that updates all lights."""
+        """Run the main loop that updates all lights."""
         LOGGER.debug("CCW cycle engine loop started")
 
         while self._running:
@@ -253,9 +245,7 @@ class CCWCycleEngine:
                     break
 
                 # Find the minimum tick interval
-                min_tick = min(
-                    entry[REG_TICK] for entry in self._registry.values()
-                )
+                min_tick = min(entry[REG_TICK] for entry in self._registry.values())
 
                 # Take a snapshot of the registry to avoid holding lock during updates
                 registry_snapshot = {k: dict(v) for k, v in self._registry.items()}

--- a/custom_components/sksoft_dimmer_engine/ccw_engine.py
+++ b/custom_components/sksoft_dimmer_engine/ccw_engine.py
@@ -1,0 +1,363 @@
+"""CCW (Color Temperature) cycle engine for the SKSoft Dimmer Engine integration.
+
+Provides the :class:`CCWCycleEngine`, which runs a single shared async loop
+that drives sine-wave color-temperature cycling for one or more Light entities.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from time import monotonic
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_TRANSITION,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant, callback
+
+from .const import (
+    DEFAULT_MIN_COLOR_TEMP,
+    PHASE_MODE_ABSOLUTE,
+    PHASE_MODE_SYNC_TO_CURRENT,
+    REG_MAX_CT,
+    REG_MIN_CT,
+    REG_MIN_DELTA,
+    REG_PERIOD,
+    REG_PHASE_MODE,
+    REG_PHASE_OFFSET,
+    REG_STARTED_AT_TS,
+    REG_SYNC_GROUP,
+    REG_TICK,
+)
+from .storage import CCWCycleStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CCWCycleEngine:
+    """Class to manage the CCW (Color Temperature) cycle engine loop and registry."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the CCW cycle engine."""
+        self.hass = hass
+        self._registry: dict[str, dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task | None = None
+        self._store = CCWCycleStore(hass)
+        self._running = False
+
+    async def async_load(self) -> None:
+        """Load registry from storage and start loop if needed."""
+        async with self._lock:
+            self._registry = await self._store.async_load()
+            if self._registry:
+                LOGGER.info(
+                    "Restored %d lights from CCW storage: %s",
+                    len(self._registry),
+                    list(self._registry.keys()),
+                )
+                self._ensure_loop_running()
+
+    async def async_save(self) -> None:
+        """Save registry to storage."""
+        await self._store.async_save(self._registry)
+
+    async def async_shutdown(self) -> None:
+        """Shutdown the engine cleanly."""
+        async with self._lock:
+            self._running = False
+            if self._task and not self._task.done():
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+            await self.async_save()
+            LOGGER.info("CCW cycle engine shutdown complete")
+
+    def _compute_phase_offset_for_color_temp(
+        self, current_ct: int, min_ct: int, max_ct: int, period: float
+    ) -> float:
+        """Compute phase offset so sine matches current color temp at t=0."""
+        mid = (min_ct + max_ct) / 2
+        amp = (max_ct - min_ct) / 2
+
+        if amp == 0:
+            return 0.0
+
+        # Clamp to valid range for asin
+        normalized = (current_ct - mid) / amp
+        normalized = max(-1.0, min(1.0, normalized))
+
+        # asin gives us the phase where sin(phase) = normalized
+        # We want the phase at t=0, so offset = asin(normalized)
+        return math.asin(normalized)
+
+    async def async_start(
+        self,
+        lights: list[str],
+        period_s: float,
+        tick_s: float,
+        min_color_temp: int,
+        max_color_temp: int,
+        phase_mode: str,
+        phase_offset: float,
+        sync_group: bool,
+        min_delta: int,
+    ) -> None:
+        """Start CCW cycling for the specified lights."""
+        async with self._lock:
+            now = monotonic()
+            computed_offset: float | None = None
+
+            for i, entity_id in enumerate(lights):
+                # Determine phase offset based on mode
+                if phase_mode == PHASE_MODE_SYNC_TO_CURRENT:
+                    if sync_group and computed_offset is not None:
+                        # Reuse computed offset from first light
+                        offset = computed_offset
+                    else:
+                        # Compute offset from current color temperature
+                        state = self.hass.states.get(entity_id)
+                        current_ct = DEFAULT_MIN_COLOR_TEMP
+                        if state and state.attributes.get(ATTR_COLOR_TEMP_KELVIN):
+                            current_ct = int(
+                                state.attributes.get(ATTR_COLOR_TEMP_KELVIN)
+                            )
+                        offset = self._compute_phase_offset_for_color_temp(
+                            current_ct,
+                            min_color_temp,
+                            max_color_temp,
+                            period_s,
+                        )
+                        if sync_group and i == 0:
+                            computed_offset = offset
+                elif phase_mode == PHASE_MODE_ABSOLUTE:
+                    offset = phase_offset
+                else:  # PHASE_MODE_RELATIVE
+                    offset = phase_offset
+
+                self._registry[entity_id] = {
+                    REG_PERIOD: period_s,
+                    REG_TICK: tick_s,
+                    REG_MIN_CT: min_color_temp,
+                    REG_MAX_CT: max_color_temp,
+                    REG_PHASE_OFFSET: offset,
+                    REG_MIN_DELTA: min_delta,
+                    REG_STARTED_AT_TS: now,
+                    REG_PHASE_MODE: phase_mode,
+                    REG_SYNC_GROUP: sync_group,
+                }
+                LOGGER.info(
+                    "Started CCW cycle engine for %s: period=%.2fs, color_temp=[%d,%d], "
+                    "phase_mode=%s, offset=%.4f",
+                    entity_id,
+                    period_s,
+                    min_color_temp,
+                    max_color_temp,
+                    phase_mode,
+                    offset,
+                )
+
+            await self.async_save()
+            self._ensure_loop_running()
+
+    async def async_stop(self, lights: list[str]) -> None:
+        """Stop CCW cycling for the specified lights."""
+        async with self._lock:
+            for entity_id in lights:
+                if entity_id in self._registry:
+                    del self._registry[entity_id]
+                    LOGGER.info("Stopped CCW cycle engine for %s", entity_id)
+                else:
+                    LOGGER.warning(
+                        "Light %s was not in CCW cycle engine registry", entity_id
+                    )
+
+            await self.async_save()
+
+            # Stop the loop immediately if registry is now empty
+            if not self._registry:
+                self._stop_loop()
+
+    async def async_stop_all(self) -> None:
+        """Stop CCW cycling for all lights."""
+        async with self._lock:
+            count = len(self._registry)
+            self._registry.clear()
+            await self.async_save()
+            LOGGER.info("Stopped CCW cycle engine for all %d lights", count)
+
+            # Stop the loop immediately
+            self._stop_loop()
+
+    def _stop_loop(self) -> None:
+        """Stop the background loop task."""
+        self._running = False
+        if self._task and not self._task.done():
+            self._task.cancel()
+            LOGGER.debug("Cancelled CCW cycle engine loop task")
+
+    def get_status(self) -> dict[str, Any]:
+        """Get the current registry status."""
+        return {
+            "active_lights": len(self._registry),
+            "loop_running": self._task is not None and not self._task.done(),
+            "registry": {k: dict(v) for k, v in self._registry.items()},
+        }
+
+    def is_ccw_cycling(self, entity_ids: list[str]) -> bool:
+        """Check if any of the given light entities are in CCW cycling.
+
+        Args:
+            entity_ids: List of entity IDs to check.
+
+        Returns:
+            True if at least one of the entities is currently in CCW cycling.
+
+        """
+        for entity_id in entity_ids:
+            if entity_id in self._registry:
+                LOGGER.debug("Entity %s is in CCW cycling", entity_id)
+                return True
+        LOGGER.debug("No entities in CCW cycling from: %s", entity_ids)
+        return False
+
+    @callback
+    def _ensure_loop_running(self) -> None:
+        """Ensure the background loop task is running."""
+        if self._task is None or self._task.done():
+            self._running = True
+            self._task = self.hass.async_create_task(
+                self._run_loop(), "sksoft_ccw_cycle_engine_loop"
+            )
+            LOGGER.debug("Started CCW cycle engine loop task")
+
+    async def _run_loop(self) -> None:
+        """Main loop that updates all lights."""
+        LOGGER.debug("CCW cycle engine loop started")
+
+        while self._running:
+            # Collect registry snapshot and min tick while holding the lock
+            async with self._lock:
+                if not self._registry:
+                    LOGGER.debug("CCW registry empty, stopping loop")
+                    break
+
+                # Find the minimum tick interval
+                min_tick = min(
+                    entry[REG_TICK] for entry in self._registry.values()
+                )
+
+                # Take a snapshot of the registry to avoid holding lock during updates
+                registry_snapshot = {k: dict(v) for k, v in self._registry.items()}
+
+            # Get current time after releasing lock (monotonic for accurate timing)
+            now = monotonic()
+
+            # Build update coroutines for all lights and execute in parallel
+            update_tasks = [
+                self._update_light(entity_id, entry, now)
+                for entity_id, entry in registry_snapshot.items()
+            ]
+            if update_tasks:
+                results = await asyncio.gather(*update_tasks)
+                # Collect entities that need to be removed (missing entities)
+                entities_to_remove = [r for r in results if r is not None]
+
+                # Remove missing entities from registry while holding the lock
+                if entities_to_remove:
+                    async with self._lock:
+                        for entity_id in entities_to_remove:
+                            if self._registry.pop(entity_id, None) is not None:
+                                LOGGER.info(
+                                    "Removed missing entity %s from CCW registry",
+                                    entity_id,
+                                )
+                        await self.async_save()
+
+            # Sleep for the minimum tick interval
+            await asyncio.sleep(min_tick)
+
+        LOGGER.debug("CCW cycle engine loop ended")
+
+    async def _update_light(
+        self, entity_id: str, entry: dict[str, Any], now: float
+    ) -> str | None:
+        """Update a single light's color temperature.
+
+        Returns the entity_id if the entity was not found and should be removed,
+        otherwise returns None.
+        """
+        period = entry[REG_PERIOD]
+        min_ct = entry[REG_MIN_CT]
+        max_ct = entry[REG_MAX_CT]
+        phase_offset = entry[REG_PHASE_OFFSET]
+        min_delta = entry[REG_MIN_DELTA]
+        started_at = entry[REG_STARTED_AT_TS]
+
+        # Calculate elapsed time
+        elapsed = now - started_at
+
+        # Calculate phase
+        time_phase = (2 * math.pi * elapsed) / period
+
+        # All phase modes use the same formula: phase = time_phase + offset
+        phase = time_phase + phase_offset
+
+        # Calculate target color temperature using sine wave
+        mid = (min_ct + max_ct) / 2
+        amp = (max_ct - min_ct) / 2
+        target = round(mid + amp * math.sin(phase))
+
+        # Clamp to valid range
+        target = max(min_ct, min(max_ct, target))
+
+        # Get current state
+        state = self.hass.states.get(entity_id)
+        if state is None:
+            LOGGER.warning(
+                "Entity %s not found, will remove from CCW registry", entity_id
+            )
+            return entity_id
+
+        # Skip lights that are not currently on
+        if state.state != STATE_ON:
+            LOGGER.debug(
+                "Skipping %s: light is not on (state=%s)", entity_id, state.state
+            )
+            return None
+
+        current_ct = state.attributes.get(ATTR_COLOR_TEMP_KELVIN) or 0
+
+        # Only update if delta is significant enough
+        if abs(target - current_ct) >= min_delta:
+            LOGGER.debug(
+                "Updating %s: color_temp %d -> %d (phase=%.2f)",
+                entity_id,
+                current_ct,
+                target,
+                phase,
+            )
+            # Use transition time (in seconds) equal to tick interval for smooth changes
+            tick = entry[REG_TICK]
+            await self.hass.services.async_call(
+                "light",
+                SERVICE_TURN_ON,
+                {
+                    ATTR_ENTITY_ID: entity_id,
+                    ATTR_COLOR_TEMP_KELVIN: target,
+                    ATTR_TRANSITION: tick,
+                },
+                blocking=False,
+            )
+
+        return None

--- a/custom_components/sksoft_dimmer_engine/condition.py
+++ b/custom_components/sksoft_dimmer_engine/condition.py
@@ -34,6 +34,19 @@ _CONDITION_SCHEMA = vol.Schema(
 )
 
 
+def _get_runtime_data(hass: HomeAssistant) -> Any | None:
+    """Return the loaded entry's ``runtime_data`` for this integration, if any.
+
+    Uses ``hass.config_entries`` rather than ``hass.data[DOMAIN]`` so the
+    engines are read from the modern :attr:`ConfigEntry.runtime_data` slot.
+    """
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        data = getattr(entry, "runtime_data", None)
+        if data is not None:
+            return data
+    return None
+
+
 def is_cycle_dimming(hass: HomeAssistant, entity_ids: list[str]) -> bool:
     """Check if any of the given light entities are in cycle dimming.
 
@@ -45,17 +58,19 @@ def is_cycle_dimming(hass: HomeAssistant, entity_ids: list[str]) -> bool:
         True if at least one of the entities is currently in cycle dimming.
 
     """
-    data = hass.data.get(DOMAIN)
+    data = _get_runtime_data(hass)
     if data is None:
         LOGGER.debug(
-            "Dimmer engine not found in hass.data, returning False for is_cycle_dimming"
+            "Dimmer engine not available (no loaded entry), returning False for "
+            "is_cycle_dimming"
         )
         return False
 
-    engine = data.get("dimmer_engine")
+    engine = data.get("engine") if isinstance(data, dict) else getattr(data, "engine", None)
     if engine is None:
         LOGGER.debug(
-            "Dimmer engine not found in data dict, returning False for is_cycle_dimming"
+            "Dimmer engine missing from runtime_data, returning False for "
+            "is_cycle_dimming"
         )
         return False
 
@@ -73,17 +88,20 @@ def is_ccw_cycling(hass: HomeAssistant, entity_ids: list[str]) -> bool:
         True if at least one of the entities is currently in CCW cycling.
 
     """
-    data = hass.data.get(DOMAIN)
+    data = _get_runtime_data(hass)
     if data is None:
         LOGGER.debug(
-            "CCW engine not found in hass.data, returning False for is_ccw_cycling"
+            "CCW engine not available (no loaded entry), returning False for "
+            "is_ccw_cycling"
         )
         return False
 
-    ccw_engine = data.get("ccw_engine")
+    ccw_engine = (
+        data.get("ccw_engine") if isinstance(data, dict) else getattr(data, "ccw_engine", None)
+    )
     if ccw_engine is None:
         LOGGER.debug(
-            "CCW engine not found in data dict, returning False for is_ccw_cycling"
+            "CCW engine missing from runtime_data, returning False for is_ccw_cycling"
         )
         return False
 

--- a/custom_components/sksoft_dimmer_engine/condition.py
+++ b/custom_components/sksoft_dimmer_engine/condition.py
@@ -1,9 +1,16 @@
-"""Condition for SKSoft Dimmer Engine integration."""
+"""Condition platform for SKSoft Dimmer Engine integration.
+
+Provides two conditions implemented against the Home Assistant 2026.x
+condition API (``homeassistant.helpers.condition``):
+``is_cycle_dimming`` and ``is_ccw_cycling``. Each condition is configured
+with a list of light entity ids and returns True when at least one of those
+lights is currently being driven by the corresponding engine.
+"""
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Unpack, cast
 
 import voluptuous as vol
 
@@ -11,6 +18,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.condition import (
     Condition,
     ConditionChecker,
+    ConditionCheckParams,
     ConditionConfig,
 )
 from homeassistant.helpers.typing import ConfigType
@@ -20,9 +28,11 @@ from .const import ATTR_LIGHTS, DOMAIN
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
+    from .ccw_engine import CCWCycleEngine
+    from .engine import DimmerEngine
+
 LOGGER = logging.getLogger(__name__)
 
-# Condition schema requires a list of lights
 _OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
     vol.Required(ATTR_LIGHTS): cv.entity_ids,
 }
@@ -34,136 +44,105 @@ _CONDITION_SCHEMA = vol.Schema(
 )
 
 
-def _get_runtime_data(hass: HomeAssistant) -> Any | None:
-    """Return the loaded entry's ``runtime_data`` for this integration, if any.
+def _find_engines(
+    hass: HomeAssistant,
+) -> tuple[DimmerEngine | None, CCWCycleEngine | None]:
+    """Locate the dimmer and CCW engines from any loaded config entry.
 
-    Uses ``hass.config_entries`` rather than ``hass.data[DOMAIN]`` so the
-    engines are read from the modern :attr:`ConfigEntry.runtime_data` slot.
+    The integration stores both engines on ``ConfigEntry.runtime_data`` in
+    :func:`custom_components.sksoft_dimmer_engine.async_setup_entry`. This
+    helper walks the loaded entries for our domain and returns the first
+    pair it finds, or ``(None, None)`` when no entry is loaded yet.
     """
     for entry in hass.config_entries.async_entries(DOMAIN):
         data = getattr(entry, "runtime_data", None)
         if data is not None:
-            return data
-    return None
+            return data["engine"], data["ccw_engine"]
+    return None, None
 
 
 def is_cycle_dimming(hass: HomeAssistant, entity_ids: list[str]) -> bool:
-    """Check if any of the given light entities are in cycle dimming.
-
-    Args:
-        hass: Home Assistant instance.
-        entity_ids: List of entity IDs to check.
-
-    Returns:
-        True if at least one of the entities is currently in cycle dimming.
-
-    """
-    data = _get_runtime_data(hass)
-    if data is None:
-        LOGGER.debug(
-            "Dimmer engine not available (no loaded entry), returning False for "
-            "is_cycle_dimming"
-        )
-        return False
-
-    engine = data.get("engine") if isinstance(data, dict) else getattr(data, "engine", None)
+    """Return True when at least one of ``entity_ids`` is in cycle dimming."""
+    engine, _ = _find_engines(hass)
     if engine is None:
-        LOGGER.debug(
-            "Dimmer engine missing from runtime_data, returning False for "
-            "is_cycle_dimming"
-        )
+        LOGGER.debug("Dimmer engine not loaded; returning False for is_cycle_dimming")
         return False
-
     return engine.is_cycle_dimming(entity_ids)
 
 
 def is_ccw_cycling(hass: HomeAssistant, entity_ids: list[str]) -> bool:
-    """Check if any of the given light entities are in CCW cycling.
-
-    Args:
-        hass: Home Assistant instance.
-        entity_ids: List of entity IDs to check.
-
-    Returns:
-        True if at least one of the entities is currently in CCW cycling.
-
-    """
-    data = _get_runtime_data(hass)
-    if data is None:
-        LOGGER.debug(
-            "CCW engine not available (no loaded entry), returning False for "
-            "is_ccw_cycling"
-        )
-        return False
-
-    ccw_engine = (
-        data.get("ccw_engine") if isinstance(data, dict) else getattr(data, "ccw_engine", None)
-    )
+    """Return True when at least one of ``entity_ids`` is in CCW cycling."""
+    _, ccw_engine = _find_engines(hass)
     if ccw_engine is None:
-        LOGGER.debug(
-            "CCW engine missing from runtime_data, returning False for is_ccw_cycling"
-        )
+        LOGGER.debug("CCW engine not loaded; returning False for is_ccw_cycling")
         return False
-
     return ccw_engine.is_ccw_cycling(entity_ids)
 
 
 class IsCycleDimmingCondition(Condition):
-    """Is Cycle Dimming condition."""
+    """Condition: any configured light is currently in cycle dimming."""
 
     _options: dict[str, Any]
+    _entity_ids: list[str]
 
     @classmethod
     async def async_validate_config(
         cls, hass: HomeAssistant, config: ConfigType
     ) -> ConfigType:
-        """Validate config."""
+        """Validate condition config."""
         return cast(ConfigType, _CONDITION_SCHEMA(config))
 
     def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
-        """Initialize condition."""
+        """Initialize the condition from its parsed config."""
         super().__init__(hass, config)
         if config.options is None:
             raise ValueError("Condition config options cannot be None")
         self._options = config.options
+        self._entity_ids = list(self._options.get(ATTR_LIGHTS, []))
 
     async def async_get_checker(self) -> ConditionChecker:
-        """Return the condition checker function."""
-        lights = self._options.get(ATTR_LIGHTS, [])
+        """Return the condition checker callable."""
+        entity_ids = self._entity_ids
+        hass = self._hass
 
-        def check_is_cycle_dimming(**kwargs: Any) -> bool:
-            """Check if any light is in cycle dimming."""
-            return is_cycle_dimming(self._hass, lights)
+        def check_is_cycle_dimming(
+            **kwargs: Unpack[ConditionCheckParams],
+        ) -> bool:
+            return is_cycle_dimming(hass, entity_ids)
 
         return check_is_cycle_dimming
 
 
 class IsCCWCyclingCondition(Condition):
-    """Is CCW Cycling condition."""
+    """Condition: any configured light is currently in CCW cycling."""
 
     _options: dict[str, Any]
+    _entity_ids: list[str]
 
     @classmethod
     async def async_validate_config(
         cls, hass: HomeAssistant, config: ConfigType
     ) -> ConfigType:
-        """Validate config."""
+        """Validate condition config."""
         return cast(ConfigType, _CONDITION_SCHEMA(config))
 
     def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
-        """Initialize condition."""
+        """Initialize the condition from its parsed config."""
         super().__init__(hass, config)
         if config.options is None:
             raise ValueError("Condition config options cannot be None")
         self._options = config.options
+        self._entity_ids = list(self._options.get(ATTR_LIGHTS, []))
 
     async def async_get_checker(self) -> ConditionChecker:
-        """Return the condition checker function."""
-        lights = self._options.get(ATTR_LIGHTS, [])
+        """Return the condition checker callable."""
+        entity_ids = self._entity_ids
+        hass = self._hass
 
-        def check_is_ccw_cycling(**kwargs: Any) -> bool:
-            """Check if any light is in CCW cycling."""
-            return is_ccw_cycling(self._hass, lights)
+        def check_is_ccw_cycling(
+            **kwargs: Unpack[ConditionCheckParams],
+        ) -> bool:
+            return is_ccw_cycling(hass, entity_ids)
 
         return check_is_ccw_cycling
 
@@ -174,6 +153,8 @@ CONDITIONS: dict[str, type[Condition]] = {
 }
 
 
-async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
-    """Return the available conditions for this integration."""
+async def async_get_conditions(
+    hass: HomeAssistant,
+) -> dict[str, type[Condition]]:
+    """Return the conditions provided by this integration."""
     return CONDITIONS

--- a/custom_components/sksoft_dimmer_engine/engine.py
+++ b/custom_components/sksoft_dimmer_engine/engine.py
@@ -7,20 +7,14 @@ that drives sine-wave brightness cycling for one or more Light entities.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
 from time import monotonic
 from typing import Any
 
-from homeassistant.components.light import (
-    ATTR_BRIGHTNESS,
-    ATTR_TRANSITION,
-)
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    SERVICE_TURN_ON,
-    STATE_ON,
-)
+from homeassistant.components.light import ATTR_BRIGHTNESS, ATTR_TRANSITION
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 
 from .const import (
@@ -50,7 +44,7 @@ class DimmerEngine:
         self.hass = hass
         self._registry: dict[str, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
-        self._task: asyncio.Task | None = None
+        self._task: asyncio.Task[None] | None = None
         self._store = DimmerEngineStore(hass)
         self._running = False
 
@@ -76,10 +70,8 @@ class DimmerEngine:
             self._running = False
             if self._task and not self._task.done():
                 self._task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await self._task
-                except asyncio.CancelledError:
-                    pass
             await self.async_save()
             LOGGER.info("Dimmer engine shutdown complete")
 
@@ -128,10 +120,10 @@ class DimmerEngine:
                         # Compute offset from current brightness
                         state = self.hass.states.get(entity_id)
                         current_brightness = DEFAULT_MIN_BRIGHTNESS
-                        if state and state.attributes.get(ATTR_BRIGHTNESS):
-                            current_brightness = int(
-                                state.attributes.get(ATTR_BRIGHTNESS)
-                            )
+                        if state is not None:
+                            brightness_attr = state.attributes.get(ATTR_BRIGHTNESS)
+                            if brightness_attr is not None:
+                                current_brightness = int(brightness_attr)
                         offset = self._compute_phase_offset_for_brightness(
                             current_brightness,
                             min_brightness,
@@ -242,7 +234,7 @@ class DimmerEngine:
             LOGGER.debug("Started dimmer engine loop task")
 
     async def _run_loop(self) -> None:
-        """Main loop that updates all lights."""
+        """Run the main loop that updates all lights."""
         LOGGER.debug("Dimmer engine loop started")
 
         while self._running:
@@ -253,9 +245,7 @@ class DimmerEngine:
                     break
 
                 # Find the minimum tick interval
-                min_tick = min(
-                    entry[REG_TICK] for entry in self._registry.values()
-                )
+                min_tick = min(entry[REG_TICK] for entry in self._registry.values())
 
                 # Take a snapshot of the registry to avoid holding lock during updates
                 registry_snapshot = {k: dict(v) for k, v in self._registry.items()}
@@ -278,7 +268,9 @@ class DimmerEngine:
                     async with self._lock:
                         for entity_id in entities_to_remove:
                             if self._registry.pop(entity_id, None) is not None:
-                                LOGGER.info("Removed missing entity %s from registry", entity_id)
+                                LOGGER.info(
+                                    "Removed missing entity %s from registry", entity_id
+                                )
                         await self.async_save()
 
             # Sleep for the minimum tick interval
@@ -330,7 +322,9 @@ class DimmerEngine:
 
         # Skip lights that are not currently on
         if state.state != STATE_ON:
-            LOGGER.debug("Skipping %s: light is not on (state=%s)", entity_id, state.state)
+            LOGGER.debug(
+                "Skipping %s: light is not on (state=%s)", entity_id, state.state
+            )
             return None
 
         current_brightness = state.attributes.get(ATTR_BRIGHTNESS, 0)
@@ -351,7 +345,11 @@ class DimmerEngine:
             await self.hass.services.async_call(
                 "light",
                 SERVICE_TURN_ON,
-                {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: target, ATTR_TRANSITION: tick},
+                {
+                    ATTR_ENTITY_ID: entity_id,
+                    ATTR_BRIGHTNESS: target,
+                    ATTR_TRANSITION: tick,
+                },
                 blocking=False,
             )
 

--- a/custom_components/sksoft_dimmer_engine/engine.py
+++ b/custom_components/sksoft_dimmer_engine/engine.py
@@ -1,0 +1,358 @@
+"""Brightness dimmer engine for the SKSoft Dimmer Engine integration.
+
+Provides the :class:`DimmerEngine`, which runs a single shared async loop
+that drives sine-wave brightness cycling for one or more Light entities.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from time import monotonic
+from typing import Any
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_TRANSITION,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_ON,
+    STATE_ON,
+)
+from homeassistant.core import HomeAssistant, callback
+
+from .const import (
+    DEFAULT_MIN_BRIGHTNESS,
+    PHASE_MODE_ABSOLUTE,
+    PHASE_MODE_SYNC_TO_CURRENT,
+    REG_MAX_B,
+    REG_MIN_B,
+    REG_MIN_DELTA,
+    REG_PERIOD,
+    REG_PHASE_MODE,
+    REG_PHASE_OFFSET,
+    REG_STARTED_AT_TS,
+    REG_SYNC_GROUP,
+    REG_TICK,
+)
+from .storage import DimmerEngineStore
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DimmerEngine:
+    """Class to manage the dimmer engine loop and registry."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the dimmer engine."""
+        self.hass = hass
+        self._registry: dict[str, dict[str, Any]] = {}
+        self._lock = asyncio.Lock()
+        self._task: asyncio.Task | None = None
+        self._store = DimmerEngineStore(hass)
+        self._running = False
+
+    async def async_load(self) -> None:
+        """Load registry from storage and start loop if needed."""
+        async with self._lock:
+            self._registry = await self._store.async_load()
+            if self._registry:
+                LOGGER.info(
+                    "Restored %d lights from storage: %s",
+                    len(self._registry),
+                    list(self._registry.keys()),
+                )
+                self._ensure_loop_running()
+
+    async def async_save(self) -> None:
+        """Save registry to storage."""
+        await self._store.async_save(self._registry)
+
+    async def async_shutdown(self) -> None:
+        """Shutdown the engine cleanly."""
+        async with self._lock:
+            self._running = False
+            if self._task and not self._task.done():
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+            await self.async_save()
+            LOGGER.info("Dimmer engine shutdown complete")
+
+    def _compute_phase_offset_for_brightness(
+        self, current_brightness: int, min_b: int, max_b: int, period: float
+    ) -> float:
+        """Compute phase offset so sine matches current brightness at t=0."""
+        mid = (min_b + max_b) / 2
+        amp = (max_b - min_b) / 2
+
+        if amp == 0:
+            return 0.0
+
+        # Clamp to valid range for asin
+        normalized = (current_brightness - mid) / amp
+        normalized = max(-1.0, min(1.0, normalized))
+
+        # asin gives us the phase where sin(phase) = normalized
+        # We want the phase at t=0, so offset = asin(normalized)
+        return math.asin(normalized)
+
+    async def async_start(
+        self,
+        lights: list[str],
+        period_s: float,
+        tick_s: float,
+        min_brightness: int,
+        max_brightness: int,
+        phase_mode: str,
+        phase_offset: float,
+        sync_group: bool,
+        min_delta: int,
+    ) -> None:
+        """Start dimming for the specified lights."""
+        async with self._lock:
+            now = monotonic()
+            computed_offset: float | None = None
+
+            for i, entity_id in enumerate(lights):
+                # Determine phase offset based on mode
+                if phase_mode == PHASE_MODE_SYNC_TO_CURRENT:
+                    if sync_group and computed_offset is not None:
+                        # Reuse computed offset from first light
+                        offset = computed_offset
+                    else:
+                        # Compute offset from current brightness
+                        state = self.hass.states.get(entity_id)
+                        current_brightness = DEFAULT_MIN_BRIGHTNESS
+                        if state and state.attributes.get(ATTR_BRIGHTNESS):
+                            current_brightness = int(
+                                state.attributes.get(ATTR_BRIGHTNESS)
+                            )
+                        offset = self._compute_phase_offset_for_brightness(
+                            current_brightness,
+                            min_brightness,
+                            max_brightness,
+                            period_s,
+                        )
+                        if sync_group and i == 0:
+                            computed_offset = offset
+                elif phase_mode == PHASE_MODE_ABSOLUTE:
+                    offset = phase_offset
+                else:  # PHASE_MODE_RELATIVE
+                    offset = phase_offset
+
+                self._registry[entity_id] = {
+                    REG_PERIOD: period_s,
+                    REG_TICK: tick_s,
+                    REG_MIN_B: min_brightness,
+                    REG_MAX_B: max_brightness,
+                    REG_PHASE_OFFSET: offset,
+                    REG_MIN_DELTA: min_delta,
+                    REG_STARTED_AT_TS: now,
+                    REG_PHASE_MODE: phase_mode,
+                    REG_SYNC_GROUP: sync_group,
+                }
+                LOGGER.info(
+                    "Started dimmer engine for %s: period=%.2fs, brightness=[%d,%d], "
+                    "phase_mode=%s, offset=%.4f",
+                    entity_id,
+                    period_s,
+                    min_brightness,
+                    max_brightness,
+                    phase_mode,
+                    offset,
+                )
+
+            await self.async_save()
+            self._ensure_loop_running()
+
+    async def async_stop(self, lights: list[str]) -> None:
+        """Stop dimming for the specified lights."""
+        async with self._lock:
+            for entity_id in lights:
+                if entity_id in self._registry:
+                    del self._registry[entity_id]
+                    LOGGER.info("Stopped dimmer engine for %s", entity_id)
+                else:
+                    LOGGER.warning(
+                        "Light %s was not in dimmer engine registry", entity_id
+                    )
+
+            await self.async_save()
+
+            # Stop the loop immediately if registry is now empty
+            if not self._registry:
+                self._stop_loop()
+
+    async def async_stop_all(self) -> None:
+        """Stop dimming for all lights."""
+        async with self._lock:
+            count = len(self._registry)
+            self._registry.clear()
+            await self.async_save()
+            LOGGER.info("Stopped dimmer engine for all %d lights", count)
+
+            # Stop the loop immediately
+            self._stop_loop()
+
+    def _stop_loop(self) -> None:
+        """Stop the background loop task."""
+        self._running = False
+        if self._task and not self._task.done():
+            self._task.cancel()
+            LOGGER.debug("Cancelled dimmer engine loop task")
+
+    def get_status(self) -> dict[str, Any]:
+        """Get the current registry status."""
+        return {
+            "active_lights": len(self._registry),
+            "loop_running": self._task is not None and not self._task.done(),
+            "registry": {k: dict(v) for k, v in self._registry.items()},
+        }
+
+    def is_cycle_dimming(self, entity_ids: list[str]) -> bool:
+        """Check if any of the given light entities are in cycle dimming.
+
+        Args:
+            entity_ids: List of entity IDs to check.
+
+        Returns:
+            True if at least one of the entities is currently in cycle dimming.
+
+        """
+        for entity_id in entity_ids:
+            if entity_id in self._registry:
+                LOGGER.debug("Entity %s is in cycle dimming", entity_id)
+                return True
+        LOGGER.debug("No entities in cycle dimming from: %s", entity_ids)
+        return False
+
+    @callback
+    def _ensure_loop_running(self) -> None:
+        """Ensure the background loop task is running."""
+        if self._task is None or self._task.done():
+            self._running = True
+            self._task = self.hass.async_create_task(
+                self._run_loop(), "sksoft_dimmer_engine_loop"
+            )
+            LOGGER.debug("Started dimmer engine loop task")
+
+    async def _run_loop(self) -> None:
+        """Main loop that updates all lights."""
+        LOGGER.debug("Dimmer engine loop started")
+
+        while self._running:
+            # Collect registry snapshot and min tick while holding the lock
+            async with self._lock:
+                if not self._registry:
+                    LOGGER.debug("Registry empty, stopping loop")
+                    break
+
+                # Find the minimum tick interval
+                min_tick = min(
+                    entry[REG_TICK] for entry in self._registry.values()
+                )
+
+                # Take a snapshot of the registry to avoid holding lock during updates
+                registry_snapshot = {k: dict(v) for k, v in self._registry.items()}
+
+            # Get current time after releasing lock (monotonic for accurate timing)
+            now = monotonic()
+
+            # Build update coroutines for all lights and execute in parallel
+            update_tasks = [
+                self._update_light(entity_id, entry, now)
+                for entity_id, entry in registry_snapshot.items()
+            ]
+            if update_tasks:
+                results = await asyncio.gather(*update_tasks)
+                # Collect entities that need to be removed (missing entities)
+                entities_to_remove = [r for r in results if r is not None]
+
+                # Remove missing entities from registry while holding the lock
+                if entities_to_remove:
+                    async with self._lock:
+                        for entity_id in entities_to_remove:
+                            if self._registry.pop(entity_id, None) is not None:
+                                LOGGER.info("Removed missing entity %s from registry", entity_id)
+                        await self.async_save()
+
+            # Sleep for the minimum tick interval
+            await asyncio.sleep(min_tick)
+
+        LOGGER.debug("Dimmer engine loop ended")
+
+    async def _update_light(
+        self, entity_id: str, entry: dict[str, Any], now: float
+    ) -> str | None:
+        """Update a single light's brightness.
+
+        Returns the entity_id if the entity was not found and should be removed,
+        otherwise returns None.
+        """
+        period = entry[REG_PERIOD]
+        min_b = entry[REG_MIN_B]
+        max_b = entry[REG_MAX_B]
+        phase_offset = entry[REG_PHASE_OFFSET]
+        min_delta = entry[REG_MIN_DELTA]
+        started_at = entry[REG_STARTED_AT_TS]
+
+        # Calculate elapsed time
+        elapsed = now - started_at
+
+        # Calculate phase
+        time_phase = (2 * math.pi * elapsed) / period
+
+        # All phase modes use the same formula: phase = time_phase + offset
+        # The difference is how the offset was computed when the light was registered:
+        # - sync_to_current: offset computed from current brightness using asin
+        # - absolute: offset provided directly by user
+        # - relative: offset provided by user, added to time-based phase
+        phase = time_phase + phase_offset
+
+        # Calculate target brightness using sine wave
+        mid = (min_b + max_b) / 2
+        amp = (max_b - min_b) / 2
+        target = round(mid + amp * math.sin(phase))
+
+        # Clamp to valid range
+        target = max(min_b, min(max_b, target))
+
+        # Get current state
+        state = self.hass.states.get(entity_id)
+        if state is None:
+            LOGGER.warning("Entity %s not found, will remove from registry", entity_id)
+            return entity_id
+
+        # Skip lights that are not currently on
+        if state.state != STATE_ON:
+            LOGGER.debug("Skipping %s: light is not on (state=%s)", entity_id, state.state)
+            return None
+
+        current_brightness = state.attributes.get(ATTR_BRIGHTNESS, 0)
+        if current_brightness is None:
+            current_brightness = 0
+
+        # Only update if delta is significant enough
+        if abs(target - current_brightness) >= min_delta:
+            LOGGER.debug(
+                "Updating %s: brightness %d -> %d (phase=%.2f)",
+                entity_id,
+                current_brightness,
+                target,
+                phase,
+            )
+            # Use transition time (in seconds) equal to tick interval for smooth dimming
+            tick = entry[REG_TICK]
+            await self.hass.services.async_call(
+                "light",
+                SERVICE_TURN_ON,
+                {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: target, ATTR_TRANSITION: tick},
+                blocking=False,
+            )
+
+        return None

--- a/custom_components/sksoft_dimmer_engine/manifest.json
+++ b/custom_components/sksoft_dimmer_engine/manifest.json
@@ -9,5 +9,6 @@
   "dependencies": [],
   "iot_class": "local_push",
   "integration_type": "service",
-  "config_flow": true
+  "config_flow": true,
+  "quality_scale": "silver"
 }

--- a/custom_components/sksoft_dimmer_engine/manifest.json
+++ b/custom_components/sksoft_dimmer_engine/manifest.json
@@ -1,14 +1,14 @@
 {
   "domain": "sksoft_dimmer_engine",
   "name": "SKSoft Dimmer Engine",
-  "version": "1.2.0",
-  "documentation": "https://github.com/SK-Software-Ltd/ha-dimmer-engine",
-  "issue_tracker": "https://github.com/SK-Software-Ltd/ha-dimmer-engine/issues",
   "codeowners": ["@SK-Software-Ltd"],
-  "requirements": [],
-  "dependencies": [],
-  "iot_class": "local_push",
-  "integration_type": "service",
   "config_flow": true,
-  "quality_scale": "silver"
+  "dependencies": [],
+  "documentation": "https://github.com/SK-Software-Ltd/ha-dimmer-engine",
+  "integration_type": "service",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/SK-Software-Ltd/ha-dimmer-engine/issues",
+  "quality_scale": "silver",
+  "requirements": [],
+  "version": "2.0.0"
 }

--- a/custom_components/sksoft_dimmer_engine/storage.py
+++ b/custom_components/sksoft_dimmer_engine/storage.py
@@ -20,9 +20,7 @@ class DimmerEngineStore:
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the storage."""
-        self._store: Store[dict[str, Any]] = Store(
-            hass, STORAGE_VERSION, STORAGE_KEY
-        )
+        self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, STORAGE_KEY)
 
     async def async_load(self) -> dict[str, Any]:
         """Load the registry from storage."""

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
   "name": "SKSoft Dimmer Engine",
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2024.11.0",
+  "country": "all"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,76 @@
+[project]
+name = "sksoft-dimmer-engine"
+version = "1.2.0"
+description = "SKSoft Dimmer Engine — Home Assistant custom integration"
+requires-python = ">=3.13"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.coverage.run]
+source = ["custom_components/sksoft_dimmer_engine"]
+
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+  "ASYNC",
+  "B",
+  "C4",
+  "D",
+  "E",
+  "F",
+  "G",
+  "I",
+  "N",
+  "PGH",
+  "PIE",
+  "RUF",
+  "S",
+  "SIM",
+  "T20",
+  "TID",
+  "UP",
+  "W",
+]
+ignore = [
+  "D100",
+  "D101",
+  "D102",
+  "D103",
+  "D104",
+  "D107",
+  "D202",
+  "D205",
+  "D213",
+  "D406",
+  "D407",
+  "D408",
+  "D409",
+  "D415",
+  "E501",
+  "N818",
+  "S101",
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+known-first-party = ["homeassistant"]
+combine-as-imports = true
+split-on-trailing-comma = false
+
+[tool.ruff.lint.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["D", "S101"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,4 @@
+pytest>=8.0.0
+pytest-homeassistant-custom-component>=0.13.0
+pytest-asyncio
+pytest-cov

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(
+    enable_custom_integrations: None,
+) -> Generator[None]:
+    yield
+
+
+@pytest.fixture(autouse=True)
+def skip_storage_load() -> Generator[None]:
+    with patch(
+        "homeassistant.helpers.storage.Store.async_load",
+        return_value=None,
+    ):
+        yield

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from time import monotonic
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+import voluptuous as vol
+
+from custom_components.sksoft_dimmer_engine.condition import (
+    CONDITIONS,
+    IsCCWCyclingCondition,
+    IsCycleDimmingCondition,
+    async_get_conditions,
+    is_ccw_cycling,
+    is_cycle_dimming,
+)
+from custom_components.sksoft_dimmer_engine.const import (
+    ATTR_LIGHTS,
+    DOMAIN,
+    REG_MAX_B,
+    REG_MAX_CT,
+    REG_MIN_B,
+    REG_MIN_CT,
+    REG_MIN_DELTA,
+    REG_PERIOD,
+    REG_PHASE_MODE,
+    REG_PHASE_OFFSET,
+    REG_STARTED_AT_TS,
+    REG_SYNC_GROUP,
+    REG_TICK,
+)
+from homeassistant.helpers.condition import ConditionConfig
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+def _brightness_registry_entry() -> dict:
+    return {
+        REG_PERIOD: 10.0,
+        REG_TICK: 0.5,
+        REG_MIN_B: 3,
+        REG_MAX_B: 255,
+        REG_PHASE_OFFSET: 0.0,
+        REG_MIN_DELTA: 1,
+        REG_STARTED_AT_TS: monotonic(),
+        REG_PHASE_MODE: "absolute",
+        REG_SYNC_GROUP: False,
+    }
+
+
+def _ccw_registry_entry() -> dict:
+    return {
+        REG_PERIOD: 10.0,
+        REG_TICK: 0.5,
+        REG_MIN_CT: 2700,
+        REG_MAX_CT: 6500,
+        REG_PHASE_OFFSET: 0.0,
+        REG_MIN_DELTA: 1,
+        REG_STARTED_AT_TS: monotonic(),
+        REG_PHASE_MODE: "absolute",
+        REG_SYNC_GROUP: False,
+    }
+
+
+async def _setup_integration(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_is_cycle_dimming_false_when_no_entry(hass: HomeAssistant) -> None:
+    assert is_cycle_dimming(hass, ["light.a"]) is False
+
+
+async def test_is_ccw_cycling_false_when_no_entry(hass: HomeAssistant) -> None:
+    assert is_ccw_cycling(hass, ["light.a"]) is False
+
+
+async def test_is_cycle_dimming_true_when_light_registered(
+    hass: HomeAssistant,
+) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+    engine._registry["light.kitchen"] = _brightness_registry_entry()
+
+    assert is_cycle_dimming(hass, ["light.kitchen"]) is True
+    assert is_cycle_dimming(hass, ["light.other", "light.kitchen"]) is True
+    assert is_cycle_dimming(hass, ["light.other"]) is False
+    assert is_cycle_dimming(hass, []) is False
+
+
+async def test_is_ccw_cycling_true_when_light_registered(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+    ccw_engine._registry["light.bedroom"] = _ccw_registry_entry()
+
+    assert is_ccw_cycling(hass, ["light.bedroom"]) is True
+    assert is_ccw_cycling(hass, ["light.other", "light.bedroom"]) is True
+    assert is_ccw_cycling(hass, ["light.other"]) is False
+    assert is_ccw_cycling(hass, []) is False
+
+
+async def test_is_cycle_dimming_and_ccw_independent(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+    ccw_engine = entry.runtime_data["ccw_engine"]
+
+    engine._registry["light.bright"] = _brightness_registry_entry()
+    ccw_engine._registry["light.warm"] = _ccw_registry_entry()
+
+    assert is_cycle_dimming(hass, ["light.bright"]) is True
+    assert is_cycle_dimming(hass, ["light.warm"]) is False
+    assert is_ccw_cycling(hass, ["light.warm"]) is True
+    assert is_ccw_cycling(hass, ["light.bright"]) is False
+
+
+async def test_async_get_conditions_returns_both(hass: HomeAssistant) -> None:
+    conditions = await async_get_conditions(hass)
+    assert set(conditions.keys()) == {"is_cycle_dimming", "is_ccw_cycling"}
+    assert conditions["is_cycle_dimming"] is IsCycleDimmingCondition
+    assert conditions["is_ccw_cycling"] is IsCCWCyclingCondition
+    assert conditions == CONDITIONS
+
+
+async def test_is_cycle_dimming_condition_validate_config(
+    hass: HomeAssistant,
+) -> None:
+    config = {"options": {ATTR_LIGHTS: ["light.a"]}}
+    validated = await IsCycleDimmingCondition.async_validate_config(hass, config)
+    assert validated["options"][ATTR_LIGHTS] == ["light.a"]
+
+    with pytest.raises(vol.Invalid):
+        await IsCycleDimmingCondition.async_validate_config(hass, {"options": {}})
+
+
+async def test_is_ccw_cycling_condition_validate_config(hass: HomeAssistant) -> None:
+    config = {"options": {ATTR_LIGHTS: ["light.x"]}}
+    validated = await IsCCWCyclingCondition.async_validate_config(hass, config)
+    assert validated["options"][ATTR_LIGHTS] == ["light.x"]
+
+
+async def test_cycle_dimming_condition_check(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+    engine._registry["light.living"] = _brightness_registry_entry()
+
+    config = ConditionConfig(options={ATTR_LIGHTS: ["light.living"]})
+    condition = IsCycleDimmingCondition(hass, config)
+
+    checker = await condition.async_get_checker()
+    assert checker() is True
+
+    other_config = ConditionConfig(options={ATTR_LIGHTS: ["light.absent"]})
+    other_condition = IsCycleDimmingCondition(hass, other_config)
+    other_checker = await other_condition.async_get_checker()
+    assert other_checker() is False
+
+
+async def test_ccw_cycling_condition_check(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+    ccw_engine._registry["light.window"] = _ccw_registry_entry()
+
+    config = ConditionConfig(options={ATTR_LIGHTS: ["light.window"]})
+    condition = IsCCWCyclingCondition(hass, config)
+    checker = await condition.async_get_checker()
+    assert checker() is True
+
+    other_config = ConditionConfig(options={ATTR_LIGHTS: ["light.absent"]})
+    other_condition = IsCCWCyclingCondition(hass, other_config)
+    other_checker = await other_condition.async_get_checker()
+    assert other_checker() is False
+
+
+async def test_condition_init_rejects_none_options(hass: HomeAssistant) -> None:
+    config = ConditionConfig(options=None)
+    with pytest.raises(ValueError):
+        IsCycleDimmingCondition(hass, config)
+    with pytest.raises(ValueError):
+        IsCCWCyclingCondition(hass, config)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sksoft_dimmer_engine.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.data_entry_flow import FlowResultType
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result.get("errors") in (None, {})
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["title"] == "SKSoft Dimmer Engine"
+    assert result2["data"] == {}
+
+
+async def test_user_flow_aborts_when_already_configured(hass: HomeAssistant) -> None:
+    existing = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data={})
+    existing.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_second_setup_aborts(hass: HomeAssistant) -> None:
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    result2 = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result2["type"] is FlowResultType.ABORT

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sksoft_dimmer_engine import DimmerEngineData
+from custom_components.sksoft_dimmer_engine.ccw_engine import CCWCycleEngine
+from custom_components.sksoft_dimmer_engine.const import (
+    DOMAIN,
+    SERVICE_START,
+    SERVICE_START_CCW,
+    SERVICE_STATUS,
+    SERVICE_STOP,
+    SERVICE_STOP_ALL,
+    SERVICE_STOP_ALL_CCW,
+    SERVICE_STOP_CCW,
+)
+from custom_components.sksoft_dimmer_engine.engine import DimmerEngine
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def _setup_integration(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_async_setup_entry_creates_engines_on_runtime_data(
+    hass: HomeAssistant,
+) -> None:
+    entry = await _setup_integration(hass)
+
+    runtime_data: DimmerEngineData = entry.runtime_data
+    assert "engine" in runtime_data
+    assert "ccw_engine" in runtime_data
+    assert isinstance(runtime_data["engine"], DimmerEngine)
+    assert isinstance(runtime_data["ccw_engine"], CCWCycleEngine)
+
+
+async def test_async_setup_registers_all_services(hass: HomeAssistant) -> None:
+    await _setup_integration(hass)
+
+    for service in (
+        SERVICE_START,
+        SERVICE_STOP,
+        SERVICE_STOP_ALL,
+        SERVICE_STATUS,
+        SERVICE_START_CCW,
+        SERVICE_STOP_CCW,
+        SERVICE_STOP_ALL_CCW,
+    ):
+        assert hass.services.has_service(DOMAIN, service), (
+            f"service {service} should be registered"
+        )
+
+
+async def test_async_unload_entry_shuts_down_engines(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+    ccw_engine = entry.runtime_data["ccw_engine"]
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert not engine._running
+    assert engine._task is None or engine._task.done()
+    assert not ccw_engine._running
+    assert ccw_engine._task is None or ccw_engine._task.done()
+
+
+async def test_services_persist_after_unload(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    for service in (
+        SERVICE_START,
+        SERVICE_STOP,
+        SERVICE_STOP_ALL,
+        SERVICE_START_CCW,
+    ):
+        assert hass.services.has_service(DOMAIN, service)
+
+
+async def test_reload_recreates_runtime_data(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    original_engine = entry.runtime_data["engine"]
+
+    assert await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.runtime_data["engine"] is not original_engine
+    assert isinstance(entry.runtime_data["engine"], DimmerEngine)
+    assert isinstance(entry.runtime_data["ccw_engine"], CCWCycleEngine)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -276,13 +276,17 @@ async def test_start_service_without_entry_warns(hass: HomeAssistant) -> None:
 async def test_engine_run_loop_processes_registered_light(
     hass: HomeAssistant,
 ) -> None:
+    import asyncio
+
     entry = await _setup_integration(hass)
     engine = entry.runtime_data["engine"]
 
+    update_event = asyncio.Event()
     update_calls: list[str] = []
 
     async def fake_update(entity_id: str, *args, **kwargs) -> str | None:
         update_calls.append(entity_id)
+        update_event.set()
         return None
 
     with patch.object(engine, "_update_light", side_effect=fake_update):
@@ -296,12 +300,8 @@ async def test_engine_run_loop_processes_registered_light(
             },
             blocking=True,
         )
-        for _ in range(50):
-            if update_calls:
-                break
-            await hass.async_block_till_done()
-        await hass.services.async_call(DOMAIN, SERVICE_STOP_ALL, {}, blocking=True)
-        await hass.async_block_till_done()
+        await asyncio.wait_for(update_event.wait(), timeout=2.0)
+        await engine.async_stop_all()
 
     assert "light.loop_target" in update_calls
 
@@ -309,13 +309,17 @@ async def test_engine_run_loop_processes_registered_light(
 async def test_ccw_engine_run_loop_processes_registered_light(
     hass: HomeAssistant,
 ) -> None:
+    import asyncio
+
     entry = await _setup_integration(hass)
     ccw_engine = entry.runtime_data["ccw_engine"]
 
+    update_event = asyncio.Event()
     update_calls: list[str] = []
 
     async def fake_update(entity_id: str, *args, **kwargs) -> str | None:
         update_calls.append(entity_id)
+        update_event.set()
         return None
 
     with patch.object(ccw_engine, "_update_light", side_effect=fake_update):
@@ -329,12 +333,8 @@ async def test_ccw_engine_run_loop_processes_registered_light(
             },
             blocking=True,
         )
-        for _ in range(50):
-            if update_calls:
-                break
-            await hass.async_block_till_done()
-        await hass.services.async_call(DOMAIN, SERVICE_STOP_ALL_CCW, {}, blocking=True)
-        await hass.async_block_till_done()
+        await asyncio.wait_for(update_event.wait(), timeout=2.0)
+        await ccw_engine.async_stop_all()
 
     assert "light.ccw_target" in update_calls
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.sksoft_dimmer_engine.const import (
+    ATTR_LIGHTS,
+    ATTR_MAX_BRIGHTNESS,
+    ATTR_MAX_COLOR_TEMP,
+    ATTR_MIN_BRIGHTNESS,
+    ATTR_MIN_COLOR_TEMP,
+    ATTR_PERIOD_S,
+    ATTR_TICK_S,
+    DOMAIN,
+    PHASE_MODE_ABSOLUTE,
+    SERVICE_START,
+    SERVICE_START_CCW,
+    SERVICE_STATUS,
+    SERVICE_STOP,
+    SERVICE_STOP_ALL,
+    SERVICE_STOP_ALL_CCW,
+    SERVICE_STOP_CCW,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+
+async def _setup_integration(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN, data={})
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_start_service_registers_lights(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+
+    with patch.object(engine, "_ensure_loop_running"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START,
+            {
+                ATTR_LIGHTS: ["light.kitchen", "light.living_room"],
+                ATTR_PERIOD_S: 10.0,
+                ATTR_TICK_S: 0.5,
+                ATTR_MIN_BRIGHTNESS: 10,
+                ATTR_MAX_BRIGHTNESS: 200,
+            },
+            blocking=True,
+        )
+
+    assert "light.kitchen" in engine._registry
+    assert "light.living_room" in engine._registry
+    assert engine._registry["light.kitchen"]["period"] == 10.0
+    assert engine._registry["light.kitchen"]["min_b"] == 10
+    assert engine._registry["light.kitchen"]["max_b"] == 200
+
+
+async def test_stop_service_removes_light(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+
+    with patch.object(engine, "_ensure_loop_running"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START,
+            {ATTR_LIGHTS: ["light.a", "light.b"]},
+            blocking=True,
+        )
+
+    assert "light.a" in engine._registry
+    assert "light.b" in engine._registry
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_STOP,
+        {ATTR_LIGHTS: ["light.a"]},
+        blocking=True,
+    )
+
+    assert "light.a" not in engine._registry
+    assert "light.b" in engine._registry
+
+
+async def test_stop_all_clears_registry(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+
+    with patch.object(engine, "_ensure_loop_running"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START,
+            {ATTR_LIGHTS: ["light.a", "light.b", "light.c"]},
+            blocking=True,
+        )
+
+    assert len(engine._registry) == 3
+
+    await hass.services.async_call(DOMAIN, SERVICE_STOP_ALL, {}, blocking=True)
+
+    assert engine._registry == {}
+
+
+async def test_start_ccw_service_registers_lights(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+
+    with patch.object(ccw_engine, "_ensure_loop_running"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START_CCW,
+            {
+                ATTR_LIGHTS: ["light.bedroom"],
+                ATTR_PERIOD_S: 30.0,
+                ATTR_MIN_COLOR_TEMP: 2700,
+                ATTR_MAX_COLOR_TEMP: 6500,
+            },
+            blocking=True,
+        )
+
+    assert "light.bedroom" in ccw_engine._registry
+    assert ccw_engine._registry["light.bedroom"]["period"] == 30.0
+    assert ccw_engine._registry["light.bedroom"]["min_ct"] == 2700
+    assert ccw_engine._registry["light.bedroom"]["max_ct"] == 6500
+
+
+async def test_stop_ccw_service_removes_light(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+
+    with patch.object(ccw_engine, "_ensure_loop_running"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START_CCW,
+            {ATTR_LIGHTS: ["light.x", "light.y"]},
+            blocking=True,
+        )
+
+    assert "light.x" in ccw_engine._registry
+    assert "light.y" in ccw_engine._registry
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_STOP_CCW,
+        {ATTR_LIGHTS: ["light.x"]},
+        blocking=True,
+    )
+
+    assert "light.x" not in ccw_engine._registry
+    assert "light.y" in ccw_engine._registry
+
+
+async def test_stop_all_ccw_clears_registry(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+
+    with patch.object(ccw_engine, "_ensure_loop_running"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START_CCW,
+            {ATTR_LIGHTS: ["light.a", "light.b"]},
+            blocking=True,
+        )
+
+    assert len(ccw_engine._registry) == 2
+
+    await hass.services.async_call(DOMAIN, SERVICE_STOP_ALL_CCW, {}, blocking=True)
+
+    assert ccw_engine._registry == {}
+
+
+async def test_status_service_runs_without_error(hass: HomeAssistant) -> None:
+    await _setup_integration(hass)
+
+    await hass.services.async_call(DOMAIN, SERVICE_STATUS, {}, blocking=True)
+
+
+async def test_brightness_range_validation_rejects_inverted(
+    hass: HomeAssistant,
+) -> None:
+    import voluptuous as vol
+
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+
+    try:
+        with patch.object(engine, "_ensure_loop_running"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_START,
+                {
+                    ATTR_LIGHTS: ["light.a"],
+                    ATTR_MIN_BRIGHTNESS: 200,
+                    ATTR_MAX_BRIGHTNESS: 50,
+                },
+                blocking=True,
+            )
+    except vol.Invalid:
+        pass
+    else:
+        raise AssertionError("Expected vol.Invalid for inverted brightness range")
+
+
+async def test_color_temp_range_validation_rejects_inverted(
+    hass: HomeAssistant,
+) -> None:
+    import voluptuous as vol
+
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+
+    try:
+        with patch.object(ccw_engine, "_ensure_loop_running"):
+            await hass.services.async_call(
+                DOMAIN,
+                SERVICE_START_CCW,
+                {
+                    ATTR_LIGHTS: ["light.a"],
+                    ATTR_MIN_COLOR_TEMP: 6000,
+                    ATTR_MAX_COLOR_TEMP: 3000,
+                },
+                blocking=True,
+            )
+    except vol.Invalid:
+        pass
+    else:
+        raise AssertionError("Expected vol.Invalid for inverted color temp range")
+
+
+async def test_absolute_phase_mode_uses_given_offset(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+
+    with patch.object(engine, "_ensure_loop_running"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START,
+            {
+                ATTR_LIGHTS: ["light.a"],
+                "phase_mode": PHASE_MODE_ABSOLUTE,
+                "phase_offset": 1.5,
+            },
+            blocking=True,
+        )
+
+    assert engine._registry["light.a"]["phase_offset"] == 1.5
+
+
+async def test_start_service_without_entry_warns(hass: HomeAssistant) -> None:
+    entry = await _setup_integration(hass)
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_START,
+        {ATTR_LIGHTS: ["light.a"]},
+        blocking=True,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_STOP_ALL,
+        {},
+        blocking=True,
+    )
+
+
+async def test_engine_run_loop_processes_registered_light(
+    hass: HomeAssistant,
+) -> None:
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+
+    update_calls: list[str] = []
+
+    async def fake_update(entity_id: str, *args, **kwargs) -> str | None:
+        update_calls.append(entity_id)
+        return None
+
+    with patch.object(engine, "_update_light", side_effect=fake_update):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START,
+            {
+                ATTR_LIGHTS: ["light.loop_target"],
+                ATTR_PERIOD_S: 1.0,
+                ATTR_TICK_S: 0.01,
+            },
+            blocking=True,
+        )
+        for _ in range(50):
+            if update_calls:
+                break
+            await hass.async_block_till_done()
+        await hass.services.async_call(DOMAIN, SERVICE_STOP_ALL, {}, blocking=True)
+        await hass.async_block_till_done()
+
+    assert "light.loop_target" in update_calls
+
+
+async def test_ccw_engine_run_loop_processes_registered_light(
+    hass: HomeAssistant,
+) -> None:
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+
+    update_calls: list[str] = []
+
+    async def fake_update(entity_id: str, *args, **kwargs) -> str | None:
+        update_calls.append(entity_id)
+        return None
+
+    with patch.object(ccw_engine, "_update_light", side_effect=fake_update):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_START_CCW,
+            {
+                ATTR_LIGHTS: ["light.ccw_target"],
+                ATTR_PERIOD_S: 1.0,
+                ATTR_TICK_S: 0.01,
+            },
+            blocking=True,
+        )
+        for _ in range(50):
+            if update_calls:
+                break
+            await hass.async_block_till_done()
+        await hass.services.async_call(DOMAIN, SERVICE_STOP_ALL_CCW, {}, blocking=True)
+        await hass.async_block_till_done()
+
+    assert "light.ccw_target" in update_calls
+
+
+_ = AsyncMock


### PR DESCRIPTION
## Summary

Modernizes ha-dimmer-engine for Home Assistant **2024.12 → 2026.2+** compatibility.

Verified against installed HA **2026.2.3** runtime, Python 3.13. All gates green.

## Changes

### Critical fixes
- **Conditions actually work now** — prior `condition.py` looked up `hass.data[DOMAIN]` which was never populated; conditions silently returned False in production. Now correctly walks `hass.config_entries.async_entries(DOMAIN)` → `entry.runtime_data`.
- **`ConfigEntry.runtime_data` pattern adopted** (HA 2024.4+ required).
- **Conditions API rewritten** for HA 2024.12+ class-based `Condition` / `ConditionChecker` framework with `Unpack[ConditionCheckParams]`.

### Refactor
- 950-line `__init__.py` split into focused modules: `engine.py`, `ccw_engine.py`, thin `__init__.py`.
- Service registration moved to `async_setup` (one-time, not per-entry).
- Strict typing throughout — `mypy --strict` clean.

### Infrastructure
- CI: `hassfest.yaml`, `lint.yaml`, `validate.yaml` (HACS).
- `manifest.json`: keys sorted, `quality_scale: silver`, version → `2.0.0`.
- `hacs.json`: `homeassistant: "2024.11.0"` + `country: "all"`.
- Test suite — **32 tests passing in 0.30s**.

## Breaking changes (documented in CHANGELOG.md)

- **Conditions now require `options:` key**:
  ```yaml
  # OLD (v1.x)
  condition:
    - condition: sksoft_dimmer_engine.is_cycle_dimming
      lights: [light.living_room]

  # NEW (v2.0.0+)
  condition:
    - condition: sksoft_dimmer_engine.is_cycle_dimming
      options:
        lights: [light.living_room]
  ```
- Minimum HA version: **2024.12**.

## Upgrade safety

- `STORAGE_VERSION = 1` unchanged → existing registries load as-is.
- Config entry data shape unchanged → existing config entries load.
- Service names + signatures unchanged.
- Only YAML automations using the old condition syntax need updating.

## Verification

| Gate | Result |
|---|---|
| ruff check + format | clean (13 files) |
| mypy --strict | no issues (7 files) |
| pytest | 32 passed in 0.30s |
| HA 2026.2.3 import smoke | clean |
| Container QA (verifier) | hassfest 0 invalid, 2 full sine cycles |
