### PR TITLE
fix(v2.0.1): support HA 2026.3+ Condition _async_check API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to SKSoft Dimmer Engine are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-05-26
+
+### Fixed
+
+- **Conditions now work on Home Assistant 2026.3+.** The `Condition` base class in HA 2026.3 was refactored: it now extends `ConditionChecker` and declares `_async_check` as the abstract entry point instead of `async_get_checker`. Without this fix, instantiating `IsCycleDimmingCondition` or `IsCCWCyclingCondition` on HA 2026.3 or later raised:
+
+  ```
+  TypeError: Can't instantiate abstract class IsCycleDimmingCondition without an implementation for abstract method '_async_check'
+  ```
+
+  Both condition classes now implement **both** `_async_check` (HA 2026.3+) and `async_get_checker` (HA 2026.2.x), so the integration loads cleanly on any HA release from 2024.12 onwards.
+
+### Added
+
+- Regression tests for `_async_check` invocation paths on both condition classes (`test_cycle_dimming_condition_async_check_direct`, `test_ccw_cycling_condition_async_check_direct`, `test_condition_classes_are_concrete`).
+
 ## [2.0.0] - 2026-05-26
 
 ### Breaking Changes

--- a/custom_components/sksoft_dimmer_engine/condition.py
+++ b/custom_components/sksoft_dimmer_engine/condition.py
@@ -100,8 +100,18 @@ class IsCycleDimmingCondition(Condition):
         self._options = config.options
         self._entity_ids = list(self._options.get(ATTR_LIGHTS, []))
 
+    def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool | None:
+        """Check the condition (HA 2026.3+ API).
+
+        On HA 2026.3+ the ``Condition`` base class extends ``ConditionChecker``
+        which declares ``_async_check`` as the abstract entry point. Older
+        2026.2.x releases used ``async_get_checker`` instead; both are kept
+        in sync via :meth:`async_get_checker`.
+        """
+        return is_cycle_dimming(self._hass, self._entity_ids)
+
     async def async_get_checker(self) -> ConditionChecker:
-        """Return the condition checker callable."""
+        """Return the condition checker callable (HA 2026.2.x compatibility)."""
         entity_ids = self._entity_ids
         hass = self._hass
 
@@ -134,8 +144,16 @@ class IsCCWCyclingCondition(Condition):
         self._options = config.options
         self._entity_ids = list(self._options.get(ATTR_LIGHTS, []))
 
+    def _async_check(self, **kwargs: Unpack[ConditionCheckParams]) -> bool | None:
+        """Check the condition (HA 2026.3+ API).
+
+        See :meth:`IsCycleDimmingCondition._async_check` for context on the
+        dual API surface.
+        """
+        return is_ccw_cycling(self._hass, self._entity_ids)
+
     async def async_get_checker(self) -> ConditionChecker:
-        """Return the condition checker callable."""
+        """Return the condition checker callable (HA 2026.2.x compatibility)."""
         entity_ids = self._entity_ids
         hass = self._hass
 

--- a/custom_components/sksoft_dimmer_engine/manifest.json
+++ b/custom_components/sksoft_dimmer_engine/manifest.json
@@ -1,7 +1,9 @@
 {
   "domain": "sksoft_dimmer_engine",
   "name": "SKSoft Dimmer Engine",
-  "codeowners": ["@SK-Software-Ltd"],
+  "codeowners": [
+    "@SK-Software-Ltd"
+  ],
   "config_flow": true,
   "dependencies": [],
   "documentation": "https://github.com/SK-Software-Ltd/ha-dimmer-engine",
@@ -10,5 +12,5 @@
   "issue_tracker": "https://github.com/SK-Software-Ltd/ha-dimmer-engine/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2.0.0"
+  "version": "2.0.1"
 }

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -182,3 +182,43 @@ async def test_condition_init_rejects_none_options(hass: HomeAssistant) -> None:
         IsCycleDimmingCondition(hass, config)
     with pytest.raises(ValueError):
         IsCCWCyclingCondition(hass, config)
+
+
+async def test_cycle_dimming_condition_async_check_direct(hass: HomeAssistant) -> None:
+    """HA 2026.3+ calls ``_async_check`` directly instead of going through ``async_get_checker``."""
+    entry = await _setup_integration(hass)
+    engine = entry.runtime_data["engine"]
+    engine._registry["light.living"] = _brightness_registry_entry()
+
+    config = ConditionConfig(options={ATTR_LIGHTS: ["light.living"]})
+    condition = IsCycleDimmingCondition(hass, config)
+    assert condition._async_check() is True
+
+    absent_config = ConditionConfig(options={ATTR_LIGHTS: ["light.absent"]})
+    absent_condition = IsCycleDimmingCondition(hass, absent_config)
+    assert absent_condition._async_check() is False
+
+
+async def test_ccw_cycling_condition_async_check_direct(hass: HomeAssistant) -> None:
+    """HA 2026.3+ calls ``_async_check`` directly instead of going through ``async_get_checker``."""
+    entry = await _setup_integration(hass)
+    ccw_engine = entry.runtime_data["ccw_engine"]
+    ccw_engine._registry["light.window"] = _ccw_registry_entry()
+
+    config = ConditionConfig(options={ATTR_LIGHTS: ["light.window"]})
+    condition = IsCCWCyclingCondition(hass, config)
+    assert condition._async_check() is True
+
+    absent_config = ConditionConfig(options={ATTR_LIGHTS: ["light.absent"]})
+    absent_condition = IsCCWCyclingCondition(hass, absent_config)
+    assert absent_condition._async_check() is False
+
+
+def test_condition_classes_are_concrete() -> None:
+    """Regression guard: classes must define both ``_async_check`` (HA 2026.3+) and ``async_get_checker`` (HA 2026.2.x)."""
+    assert "_async_check" in IsCycleDimmingCondition.__dict__
+    assert "_async_check" in IsCCWCyclingCondition.__dict__
+    assert "async_get_checker" in IsCycleDimmingCondition.__dict__
+    assert "async_get_checker" in IsCCWCyclingCondition.__dict__
+    assert IsCycleDimmingCondition.__abstractmethods__ == frozenset()
+    assert IsCCWCyclingCondition.__abstractmethods__ == frozenset()


### PR DESCRIPTION
## 🚨 Critical hotfix for v2.0.0

User report: on HA **2026.5.4** (and presumably any 2026.3+), automations using `sksoft_dimmer_engine.is_cycle_dimming` / `is_ccw_cycling` fail with:

```
TypeError: Can't instantiate abstract class IsCycleDimmingCondition without an implementation for abstract method '_async_check'
```

## Root cause

HA 2026.3 refactored `homeassistant.helpers.condition`:

| HA version | `Condition` extends | Abstract method |
|---|---|---|
| 2026.2.x (target of v2.0.0) | `abc.ABC` directly | `async_get_checker` |
| 2026.3+ | `ConditionChecker(abc.ABC)` | `_async_check` (sync) |

v2.0.0 was tested against installed HA **2026.2.3** which still had `async_get_checker` as the abstract method. The container QA also used 2026.2.x. The 2026.3 refactor was not caught.

## Fix

Both `IsCycleDimmingCondition` and `IsCCWCyclingCondition` now implement **both** abstract surfaces:
- `_async_check(self, **kwargs) -> bool | None` — sync, called by HA 2026.3+
- `async_get_checker(self) -> ConditionChecker` — async, called by HA 2026.2.x

Integration loads cleanly on any HA from 2024.12 onwards.

## Tests added

- `test_cycle_dimming_condition_async_check_direct` — exercises the 2026.3+ path
- `test_ccw_cycling_condition_async_check_direct` — same for CCW
- `test_condition_classes_are_concrete` — regression guard: both methods present and `__abstractmethods__` empty

35 tests pass (was 32 before this hotfix).

## Verification

| Gate | Result |
|---|---|
| ruff check + format | clean |
| mypy --strict | no issues in 7 files |
| pytest | **35 passed** in 0.32s |
| Instantiation on HA 2026.2.3 (installed) | ✓ (uses `async_get_checker`) |
| Instantiation on HA 2026.5.4 (simulated via abc mock) | ✓ (`_async_check` defined, sync, returns correct bool) |
