### PR TITLE
feat(ci): HA compatibility matrix + fix minimum HA version

### DIFF
--- a/.github/workflows/test-matrix.yaml
+++ b/.github/workflows/test-matrix.yaml
@@ -1,0 +1,60 @@
+name: HA Compatibility Matrix
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 6 * * *"
+
+jobs:
+  smoke:
+    name: "Smoke (HA ${{ matrix.ha }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ha: "2026.1.0"
+            pthac: "0.13.305"
+            python: "3.13"
+          - ha: "2026.2.3"
+            pthac: "0.13.316"
+            python: "3.13"
+          - ha: "2026.4.4"
+            pthac: "0.13.325"
+            python: "3.13"
+          - ha: "2026.5.4"
+            pthac: "0.13.333"
+            python: "3.13"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install pinned HA + test deps
+        run: |
+          pip install --upgrade pip
+          pip install "pytest-homeassistant-custom-component==${{ matrix.pthac }}"
+      - name: Verify installed HA version
+        run: |
+          python -c "from homeassistant.const import __version__; print(__version__)"
+          python -c "from homeassistant.const import __version__; assert __version__ == '${{ matrix.ha }}', f'expected ${{ matrix.ha }}, got {__version__}'"
+      - name: Run compatibility smoke tests
+        run: pytest tests_compat/ -v
+
+  full-suite:
+    name: "Full pytest (HA latest stable)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install latest pytest-homeassistant-custom-component
+        run: |
+          pip install --upgrade pip
+          pip install pytest-homeassistant-custom-component
+      - name: Show HA version
+        run: python -c "from homeassistant.const import __version__; print('HA', __version__)"
+      - name: Run full test suite
+        run: pytest tests/ -v

--- a/.github/workflows/test-matrix.yaml
+++ b/.github/workflows/test-matrix.yaml
@@ -22,10 +22,10 @@ jobs:
             python: "3.13"
           - ha: "2026.4.4"
             pthac: "0.13.325"
-            python: "3.13"
+            python: "3.14"
           - ha: "2026.5.4"
             pthac: "0.13.333"
-            python: "3.13"
+            python: "3.14"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install latest pytest-homeassistant-custom-component
         run: |
           pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to SKSoft Dimmer Engine are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-05-26
+
+### Fixed
+
+- **Correct minimum Home Assistant version declared in `hacs.json`.** Previously declared `2024.11.0`, but the integration imports `Condition`, `ConditionChecker`, `ConditionCheckParams`, and `ConditionConfig` from `homeassistant.helpers.condition` — symbols that were only introduced together in **HA 2026.1.0**. Users on HA 2024.12 – 2025.x would have hit cryptic `ImportError` on integration load. HACS now blocks install on HA versions below `2026.1.0`.
+
+### Added
+
+- **CI compatibility matrix workflow** (`.github/workflows/test-matrix.yaml`) runs daily and on every push, exercising the integration against four pinned Home Assistant versions: `2026.1.0`, `2026.2.3`, `2026.4.4`, `2026.5.4`. This is the safeguard against the v2.0.0 → v2.0.1 regression class — any future HA-API rename now fails CI before a release ships instead of after.
+- **Smoke compatibility test suite** (`tests_compat/test_smoke_compat.py`) that verifies imports resolve, both condition classes are concrete (no missing abstract methods), and the `async_get_conditions` registry returns both. Kept isolated from the main test suite so it has no HA-event-loop dependencies and runs on every HA version in the matrix.
+
 ## [2.0.1] - 2026-05-26
 
 ### Fixed

--- a/custom_components/sksoft_dimmer_engine/manifest.json
+++ b/custom_components/sksoft_dimmer_engine/manifest.json
@@ -12,5 +12,5 @@
   "issue_tracker": "https://github.com/SK-Software-Ltd/ha-dimmer-engine/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
   "name": "SKSoft Dimmer Engine",
   "render_readme": true,
-  "homeassistant": "2024.11.0",
+  "homeassistant": "2026.1.0",
   "country": "all"
 }

--- a/tests_compat/conftest.py
+++ b/tests_compat/conftest.py
@@ -1,0 +1,14 @@
+"""Conftest for compatibility smoke tests.
+
+Kept separate from tests/conftest.py because smoke tests must not require
+the HA event loop / fixtures — they exercise import + instantiation only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))

--- a/tests_compat/test_smoke_compat.py
+++ b/tests_compat/test_smoke_compat.py
@@ -1,0 +1,96 @@
+"""Smoke tests for HA version compatibility matrix.
+
+These tests run against EVERY HA version in the CI matrix to catch API
+breakage early. They intentionally avoid heavy integration-setup paths
+(which differ across HA versions) and exercise just the surfaces that
+historically broke:
+
+- Imports resolve on the target HA version
+- Both condition classes are *concrete* (no missing abstract methods)
+- Both condition classes can be instantiated without an HA event loop
+- The `async_get_conditions` registry returns both classes
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    pass
+
+
+def test_module_imports() -> None:
+    """All package modules must import cleanly on the target HA version."""
+    import custom_components.sksoft_dimmer_engine  # noqa: F401
+    from custom_components.sksoft_dimmer_engine import (  # noqa: F401
+        ccw_engine,
+        condition,
+        config_flow,
+        const,
+        engine,
+        storage,
+    )
+
+
+def test_condition_classes_are_concrete() -> None:
+    """No abstract methods may be left on our condition classes.
+
+    Regression: HA 2026.3 renamed the abstract from `async_get_checker`
+    to `_async_check`. v2.0.0 implemented only the former and crashed
+    on 2026.3+ with: "Can't instantiate abstract class … without an
+    implementation for abstract method '_async_check'".
+    """
+    from custom_components.sksoft_dimmer_engine.condition import (
+        IsCCWCyclingCondition,
+        IsCycleDimmingCondition,
+    )
+
+    assert IsCycleDimmingCondition.__abstractmethods__ == frozenset(), (
+        f"IsCycleDimmingCondition has unimplemented abstract methods: "
+        f"{IsCycleDimmingCondition.__abstractmethods__}"
+    )
+    assert IsCCWCyclingCondition.__abstractmethods__ == frozenset(), (
+        f"IsCCWCyclingCondition has unimplemented abstract methods: "
+        f"{IsCCWCyclingCondition.__abstractmethods__}"
+    )
+
+
+def test_condition_classes_can_be_instantiated() -> None:
+    """Conditions must be instantiable — the symptom of the 2.0.0 regression."""
+    from custom_components.sksoft_dimmer_engine.condition import (
+        IsCCWCyclingCondition,
+        IsCycleDimmingCondition,
+    )
+    from homeassistant.helpers.condition import ConditionConfig
+
+    hass = MagicMock()
+    config = ConditionConfig(options={"lights": ["light.x"]})
+
+    IsCycleDimmingCondition(hass, config)
+    IsCCWCyclingCondition(hass, config)
+
+
+@pytest.mark.asyncio
+async def test_async_get_conditions_registry() -> None:
+    """HA discovers conditions via this entry point — must return both classes."""
+    from custom_components.sksoft_dimmer_engine.condition import async_get_conditions
+
+    hass = MagicMock()
+    conditions = await async_get_conditions(hass)
+
+    assert "is_cycle_dimming" in conditions
+    assert "is_ccw_cycling" in conditions
+    assert len(conditions) == 2
+
+
+def test_manifest_minimum_ha_version_in_hacs_json() -> None:
+    """hacs.json must declare the HA minimum version we actually support."""
+    import json
+    from pathlib import Path
+
+    hacs_path = Path(__file__).parent.parent / "hacs.json"
+    data = json.loads(hacs_path.read_text())
+    assert "homeassistant" in data, "hacs.json must declare homeassistant minimum"


### PR DESCRIPTION
## What

Adds a CI matrix that runs the integration's smoke tests against 4 pinned HA versions on every push and daily at 06:00 UTC:

| HA | pytest-homeassistant-custom-component |
|---|---|
| 2026.1.0 (minimum) | 0.13.305 |
| 2026.2.3 | 0.13.316 |
| 2026.4.4 | 0.13.325 |
| 2026.5.4 (current stable) | 0.13.333 |

## Why

The v2.0.0 → v2.0.1 cycle exposed two real gaps:

1. **API drift not caught**: HA 2026.3 renamed `async_get_checker` → `_async_check` on `Condition`. v2.0.0 tested fine against 2026.2.3 but crashed on 2026.5.4 with "Can't instantiate abstract class". This matrix catches that class of break.

2. **Wrong declared minimum**: `hacs.json` claimed minimum HA 2024.11.0, but the integration imports `ConditionConfig`/`ConditionChecker`/`ConditionCheckParams` — symbols only introduced together in **HA 2026.1.0**. Users on HA 2024.12 – 2025.x would hit cryptic `ImportError` on load. HACS now blocks too-old HA installs.

## Smoke tests

`tests_compat/test_smoke_compat.py` covers exactly the regression class we hit:

- Imports resolve on the target HA
- Both condition classes are *concrete* (no missing abstract methods)
- Both can be instantiated (the symptom of the 2.0.0 bug)
- `async_get_conditions` registry returns both

Kept isolated from `tests/` so the smoke run has no HA event-loop fixture deps.

## Local verification

- ruff: clean
- ruff format: clean
- pytest full suite: **40 passed** (35 existing + 5 smoke compat)

## Release plan

Once CI matrix is green on this PR I'll cut v2.0.2.